### PR TITLE
Allow reusing Scope temp variables

### DIFF
--- a/src/main/java/io/airlift/bytecode/ParameterizedType.java
+++ b/src/main/java/io/airlift/bytecode/ParameterizedType.java
@@ -220,12 +220,7 @@ public class ParameterizedType
         }
 
         ParameterizedType that = (ParameterizedType) o;
-
-        if (!type.equals(that.type)) {
-            return false;
-        }
-
-        return true;
+        return type.equals(that.type);
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/ParameterizedType.java
+++ b/src/main/java/io/airlift/bytecode/ParameterizedType.java
@@ -110,7 +110,7 @@ public class ParameterizedType
         this.className = getPathName(type);
         this.simpleName = type.getSimpleName();
 
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(parameters.length);
         for (Class<?> parameter : parameters) {
             builder.add(toInternalIdentifier(parameter));
         }
@@ -128,7 +128,7 @@ public class ParameterizedType
         this.className = getPathName(type);
         this.simpleName = type.getSimpleName();
 
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(parameters.length);
         for (ParameterizedType parameter : parameters) {
             builder.add(parameter.toString());
         }


### PR DESCRIPTION
Allows temp variables to be reused within the same `Scope` instance after being released. This allows relatively smaller method bytecode sizes by using relatively fewer variable slots- which becomes significant since:
- accessing variable slots 0 - 3 is a single bytecode operation: `aload_0, aload_1, aload_2, aload_3`
- accessing variable slots 3 - 255 takes two bytes: `aload <index>`
- accessing variable slots 256+ takes 4 bytes: `wide aload <two byte index>`

Similar overheads are incurred when storing values into a variable, and for other non-reference type load/store bytecode operations.