### PR TITLE
Modernize codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>347</version>
+        <version>395</version>
     </parent>
 
     <artifactId>bytecode</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
+++ b/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
@@ -39,7 +39,6 @@ public class AnnotationDefinition
             .add(Class.class)
             .add(ParameterizedType.class)
             .add(AnnotationDefinition.class)
-            .add(Enum.class)
             .build();
 
     private final ParameterizedType type;
@@ -155,12 +154,19 @@ public class AnnotationDefinition
                 checkArgument(v != null, "List contains a null element");
                 // annotation members hold only one-dimensional arrays
                 checkArgument(!(v instanceof List), "List contains a nested list");
-                checkArgument(ALLOWED_TYPES.contains(v.getClass()), "List contains invalid type %s", v.getClass());
+                checkArgument(isAllowedType(v), "List contains invalid type %s", v.getClass());
             }
         }
         else {
-            checkArgument(ALLOWED_TYPES.contains(value.getClass()), "Invalid value type %s", value.getClass());
+            checkArgument(isAllowedType(value), "Invalid value type %s", value.getClass());
         }
+    }
+
+    private static boolean isAllowedType(Object value)
+    {
+        // an enum constant's class is the enum type, or an anonymous subclass
+        // for constants with a body, so enums cannot be checked with a type set
+        return value instanceof Enum || ALLOWED_TYPES.contains(value.getClass());
     }
 
     public void visitClassAnnotation(ClassVisitor visitor)
@@ -209,7 +215,7 @@ public class AnnotationDefinition
         }
         else if (value instanceof Enum) {
             Enum<?> enumConstant = (Enum<?>) value;
-            visitor.visitEnum(name, type(enumConstant.getDeclaringClass()).getClassName(), enumConstant.name());
+            visitor.visitEnum(name, type(enumConstant.getDeclaringClass()).getType(), enumConstant.name());
         }
         else if (value instanceof ParameterizedType) {
             ParameterizedType parameterizedType = (ParameterizedType) value;

--- a/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
+++ b/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
@@ -152,10 +152,10 @@ public class AnnotationDefinition
         if (value instanceof List) {
             // todo verify list contains single type
             for (Object v : (List<Object>) value) {
+                checkArgument(v != null, "List contains a null element");
+                // annotation members hold only one-dimensional arrays
+                checkArgument(!(v instanceof List), "List contains a nested list");
                 checkArgument(ALLOWED_TYPES.contains(v.getClass()), "List contains invalid type %s", v.getClass());
-                if (v instanceof List) {
-                    isValidType(value);
-                }
             }
         }
         else {

--- a/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
+++ b/src/main/java/io/airlift/bytecode/AnnotationDefinition.java
@@ -148,9 +148,9 @@ public class AnnotationDefinition
 
     private static void isValidType(Object value)
     {
-        if (value instanceof List) {
+        if (value instanceof List<?> list) {
             // todo verify list contains single type
-            for (Object v : (List<Object>) value) {
+            for (Object v : list) {
                 checkArgument(v != null, "List contains a null element");
                 // annotation members hold only one-dimensional arrays
                 checkArgument(!(v instanceof List), "List contains a nested list");
@@ -208,32 +208,22 @@ public class AnnotationDefinition
 
     private static void visit(AnnotationVisitor visitor, String name, Object value)
     {
-        if (value instanceof AnnotationDefinition) {
-            AnnotationDefinition annotation = (AnnotationDefinition) value;
-            AnnotationVisitor annotationVisitor = visitor.visitAnnotation(name, annotation.type.getType());
-            annotation.visit(annotationVisitor);
-        }
-        else if (value instanceof Enum) {
-            Enum<?> enumConstant = (Enum<?>) value;
-            visitor.visitEnum(name, type(enumConstant.getDeclaringClass()).getType(), enumConstant.name());
-        }
-        else if (value instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) value;
-            visitor.visit(name, Type.getType(parameterizedType.getType()));
-        }
-        else if (value instanceof Class) {
-            Class<?> clazz = (Class<?>) value;
-            visitor.visit(name, Type.getType(clazz));
-        }
-        else if (value instanceof List) {
-            AnnotationVisitor arrayVisitor = visitor.visitArray(name);
-            for (Object element : (List<?>) value) {
-                visit(arrayVisitor, null, element);
+        switch (value) {
+            case AnnotationDefinition annotation -> {
+                AnnotationVisitor annotationVisitor = visitor.visitAnnotation(name, annotation.type.getType());
+                annotation.visit(annotationVisitor);
             }
-            arrayVisitor.visitEnd();
-        }
-        else {
-            visitor.visit(name, value);
+            case Enum<?> enumConstant -> visitor.visitEnum(name, type(enumConstant.getDeclaringClass()).getType(), enumConstant.name());
+            case ParameterizedType parameterizedType -> visitor.visit(name, Type.getType(parameterizedType.getType()));
+            case Class<?> clazz -> visitor.visit(name, Type.getType(clazz));
+            case List<?> list -> {
+                AnnotationVisitor arrayVisitor = visitor.visitArray(name);
+                for (Object element : list) {
+                    visit(arrayVisitor, null, element);
+                }
+                arrayVisitor.visitEnd();
+            }
+            case null, default -> visitor.visit(name, value);
         }
     }
 }

--- a/src/main/java/io/airlift/bytecode/ArrayOpCode.java
+++ b/src/main/java/io/airlift/bytecode/ArrayOpCode.java
@@ -14,8 +14,7 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableMap;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.Map;
 

--- a/src/main/java/io/airlift/bytecode/BytecodeBlock.java
+++ b/src/main/java/io/airlift/bytecode/BytecodeBlock.java
@@ -23,8 +23,6 @@ import io.airlift.bytecode.instruction.TypeInstruction;
 import io.airlift.bytecode.instruction.VariableInstruction;
 import org.objectweb.asm.MethodVisitor;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -53,7 +51,6 @@ import static io.airlift.bytecode.instruction.VariableInstruction.loadVariable;
 import static io.airlift.bytecode.instruction.VariableInstruction.storeVariable;
 
 @SuppressWarnings("UnusedDeclaration")
-@NotThreadSafe
 public class BytecodeBlock
         implements BytecodeNode
 {

--- a/src/main/java/io/airlift/bytecode/BytecodeBlock.java
+++ b/src/main/java/io/airlift/bytecode/BytecodeBlock.java
@@ -93,7 +93,7 @@ public class BytecodeBlock
 
     public BytecodeBlock comment(String comment, Object... args)
     {
-        nodes.add(new Comment(String.format(comment, args)));
+        nodes.add(new Comment(comment.formatted(args)));
         return this;
     }
 
@@ -484,7 +484,8 @@ public class BytecodeBlock
         return this;
     }
 
-    public BytecodeNode invokeDynamic(String name,
+    public BytecodeNode invokeDynamic(
+            String name,
             ParameterizedType returnType,
             Iterable<ParameterizedType> parameterTypes,
             Method bootstrapMethod,
@@ -818,24 +819,11 @@ public class BytecodeBlock
         ParameterizedType type = variable.getType();
         if (type.getType().length() == 1) {
             switch (type.getType().charAt(0)) {
-                case 'B':
-                case 'Z':
-                case 'S':
-                case 'C':
-                case 'I':
-                    nodes.add(loadInt(0));
-                    break;
-                case 'F':
-                    nodes.add(loadFloat(0));
-                    break;
-                case 'D':
-                    nodes.add(loadDouble(0));
-                    break;
-                case 'J':
-                    nodes.add(loadLong(0));
-                    break;
-                default:
-                    checkArgument(false, "Unknown type '%s'", variable.getType());
+                case 'B', 'Z', 'S', 'C', 'I' -> nodes.add(loadInt(0));
+                case 'F' -> nodes.add(loadFloat(0));
+                case 'D' -> nodes.add(loadDouble(0));
+                case 'J' -> nodes.add(loadLong(0));
+                default -> checkArgument(false, "Unknown type '%s'", variable.getType());
             }
         }
         else {

--- a/src/main/java/io/airlift/bytecode/BytecodeBlock.java
+++ b/src/main/java/io/airlift/bytecode/BytecodeBlock.java
@@ -50,7 +50,6 @@ import static io.airlift.bytecode.instruction.TypeInstruction.instanceOf;
 import static io.airlift.bytecode.instruction.VariableInstruction.loadVariable;
 import static io.airlift.bytecode.instruction.VariableInstruction.storeVariable;
 
-@SuppressWarnings("UnusedDeclaration")
 public class BytecodeBlock
         implements BytecodeNode
 {

--- a/src/main/java/io/airlift/bytecode/ClassDefinition.java
+++ b/src/main/java/io/airlift/bytecode/ClassDefinition.java
@@ -17,8 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.objectweb.asm.ClassVisitor;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -34,7 +32,6 @@ import static java.util.Objects.requireNonNull;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
 import static org.objectweb.asm.Opcodes.V17;
 
-@NotThreadSafe
 public class ClassDefinition
 {
     private final EnumSet<Access> access;

--- a/src/main/java/io/airlift/bytecode/Comment.java
+++ b/src/main/java/io/airlift/bytecode/Comment.java
@@ -37,9 +37,7 @@ public class Comment
     }
 
     @Override
-    public void accept(MethodVisitor visitor, MethodGenerationContext generationContext)
-    {
-    }
+    public void accept(MethodVisitor visitor, MethodGenerationContext generationContext) {}
 
     @Override
     public String toString()

--- a/src/main/java/io/airlift/bytecode/DumpBytecodeVisitor.java
+++ b/src/main/java/io/airlift/bytecode/DumpBytecodeVisitor.java
@@ -196,8 +196,7 @@ public class DumpBytecodeVisitor
     private void visitBlockContents(BytecodeBlock block)
     {
         for (BytecodeNode node : block.getChildNodes()) {
-            if (node instanceof BytecodeBlock) {
-                BytecodeBlock childBlock = (BytecodeBlock) node;
+            if (node instanceof BytecodeBlock childBlock) {
                 if (childBlock.getDescription() != null) {
                     visitBlock(block, childBlock);
                 }

--- a/src/main/java/io/airlift/bytecode/DumpBytecodeVisitor.java
+++ b/src/main/java/io/airlift/bytecode/DumpBytecodeVisitor.java
@@ -13,8 +13,6 @@
  */
 package io.airlift.bytecode;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import io.airlift.bytecode.control.CaseStatement;
 import io.airlift.bytecode.control.DoWhileLoop;
 import io.airlift.bytecode.control.ForLoop;
@@ -55,7 +53,6 @@ import java.util.List;
 
 import static io.airlift.bytecode.Access.INTERFACE;
 import static io.airlift.bytecode.ParameterizedType.type;
-import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
 public class DumpBytecodeVisitor
@@ -279,7 +276,8 @@ public class DumpBytecodeVisitor
     @Override
     public Void visitInvoke(BytecodeNode parent, InvokeInstruction invokeInstruction)
     {
-        printLine("invoke %s.%s%s",
+        printLine(
+                "invoke %s.%s%s",
                 invokeInstruction.getTarget().getJavaClassName(),
                 invokeInstruction.getName(),
                 invokeInstruction.getMethodDescription());
@@ -289,7 +287,8 @@ public class DumpBytecodeVisitor
     @Override
     public Void visitInvokeDynamic(BytecodeNode parent, InvokeDynamicInstruction invokeDynamicInstruction)
     {
-        printLine("invokeDynamic %s%s %s",
+        printLine(
+                "invokeDynamic %s%s %s",
                 invokeDynamicInstruction.getName(),
                 invokeDynamicInstruction.getMethodDescription(),
                 invokeDynamicInstruction.getBootstrapArguments());
@@ -409,7 +408,7 @@ public class DumpBytecodeVisitor
         indentLevel++;
         visitNestedNode("expression", switchStatement.expression(), switchStatement);
         for (CaseStatement caseStatement : switchStatement.cases()) {
-            visitNestedNode(format("case %s:", caseStatement.getKey()), caseStatement.getBody(), switchStatement);
+            visitNestedNode("case %s:".formatted(caseStatement.getKey()), caseStatement.getBody(), switchStatement);
         }
         if (switchStatement.getDefaultBody() != null) {
             visitNestedNode("default:", switchStatement.getDefaultBody(), switchStatement);
@@ -553,24 +552,24 @@ public class DumpBytecodeVisitor
 
     public void printLine(String line)
     {
-        out.println(format("%s%s", indent(indentLevel), line));
+        out.println("%s%s".formatted(indent(indentLevel), line));
     }
 
     public void printLine(String format, Object... args)
     {
-        String line = format(format, args);
-        out.println(format("%s%s", indent(indentLevel), line));
+        String line = format.formatted(args);
+        out.println("%s%s".formatted(indent(indentLevel), line));
     }
 
     public void printWords(String... words)
     {
-        String line = Joiner.on(" ").join(words);
-        out.println(format("%s%s", indent(indentLevel), line));
+        String line = String.join(" ", words);
+        out.println("%s%s".formatted(indent(indentLevel), line));
     }
 
     private String indent(int level)
     {
-        return Strings.repeat("    ", level);
+        return "    ".repeat(level);
     }
 
     private void visitNestedNode(String description, BytecodeNode node, BytecodeNode parent)
@@ -621,13 +620,13 @@ public class DumpBytecodeVisitor
 
         public void print()
         {
-            printLine(Joiner.on(separator).join(parts));
+            printLine(parts.stream().map(Object::toString).collect(joining(separator)));
         }
 
         @Override
         public String toString()
         {
-            return Joiner.on(separator).join(parts);
+            return parts.stream().map(Object::toString).collect(joining(separator));
         }
     }
 }

--- a/src/main/java/io/airlift/bytecode/FieldDefinition.java
+++ b/src/main/java/io/airlift/bytecode/FieldDefinition.java
@@ -92,7 +92,8 @@ public class FieldDefinition
 
     public void visit(ClassVisitor visitor)
     {
-        FieldVisitor fieldVisitor = visitor.visitField(toAccessModifier(access),
+        FieldVisitor fieldVisitor = visitor.visitField(
+                toAccessModifier(access),
                 name,
                 type.getType(),
                 type.getGenericSignature(),

--- a/src/main/java/io/airlift/bytecode/FieldDefinition.java
+++ b/src/main/java/io/airlift/bytecode/FieldDefinition.java
@@ -16,10 +16,9 @@ package io.airlift.bytecode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.errorprone.annotations.Immutable;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
-
-import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayList;
 import java.util.EnumSet;

--- a/src/main/java/io/airlift/bytecode/FieldDefinition.java
+++ b/src/main/java/io/airlift/bytecode/FieldDefinition.java
@@ -27,7 +27,6 @@ import java.util.List;
 import static io.airlift.bytecode.Access.toAccessModifier;
 import static io.airlift.bytecode.ParameterizedType.type;
 
-@SuppressWarnings("UnusedDeclaration")
 @Immutable
 public class FieldDefinition
 {

--- a/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
+++ b/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
@@ -68,9 +68,22 @@ public class HiddenClassGenerator
 
     public <T> Class<? extends T> defineHiddenClass(ClassDefinition classDefinition, Class<T> superType, Optional<Object> classData)
     {
-        ClassInfoLoader classInfoLoader = createClassInfoLoader(classDefinition, lookup);
-        byte[] bytecode = byteCodeGenerator.generateByteCode(classInfoLoader, classDefinition);
+        return defineHiddenClass(generateBytes(classDefinition), superType, classData);
+    }
 
+    /**
+     * Generates the class file bytes of a hidden class without defining it. The bytes can
+     * be passed to {@link #defineHiddenClass(byte[], Class, Optional)} any number of times,
+     * each definition with its own class data.
+     */
+    public byte[] generateBytes(ClassDefinition classDefinition)
+    {
+        ClassInfoLoader classInfoLoader = createClassInfoLoader(classDefinition, lookup);
+        return byteCodeGenerator.generateByteCode(classInfoLoader, classDefinition);
+    }
+
+    public <T> Class<? extends T> defineHiddenClass(byte[] bytecode, Class<T> superType, Optional<Object> classData)
+    {
         Lookup definedClassLookup;
         try {
             if (classData.isEmpty()) {

--- a/src/main/java/io/airlift/bytecode/MethodDefinition.java
+++ b/src/main/java/io/airlift/bytecode/MethodDefinition.java
@@ -262,7 +262,7 @@ public class MethodDefinition
     {
         StringBuilder sb = new StringBuilder();
         Joiner.on(' ').appendTo(sb, access).append(' ');
-        sb.append(returnType.getJavaClassName()).append(' ');
+        sb.append(returnType.getJavaClassName()).append(' ').append(name);
         sb.append(parameters.stream().map(Parameter::getSourceString).collect(joining(", ", "(", ")")));
         return sb.toString();
     }

--- a/src/main/java/io/airlift/bytecode/MethodDefinition.java
+++ b/src/main/java/io/airlift/bytecode/MethodDefinition.java
@@ -35,7 +35,6 @@ import static java.util.Objects.requireNonNullElseGet;
 import static java.util.stream.Collectors.joining;
 import static org.objectweb.asm.Opcodes.RETURN;
 
-@SuppressWarnings("UnusedDeclaration")
 public class MethodDefinition
 {
     private final Scope scope;

--- a/src/main/java/io/airlift/bytecode/MethodDefinition.java
+++ b/src/main/java/io/airlift/bytecode/MethodDefinition.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.bytecode;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -258,11 +257,9 @@ public class MethodDefinition
 
     public String toSourceString()
     {
-        StringBuilder sb = new StringBuilder();
-        Joiner.on(' ').appendTo(sb, access).append(' ');
-        sb.append(returnType.getJavaClassName()).append(' ').append(name);
-        sb.append(parameters.stream().map(Parameter::getSourceString).collect(joining(", ", "(", ")")));
-        return sb.toString();
+        return access.stream().map(Access::toString).collect(joining(" ")) +
+                ' ' + returnType.getJavaClassName() + ' ' + name +
+                parameters.stream().map(Parameter::getSourceString).collect(joining(", ", "(", ")"));
     }
 
     @Override
@@ -311,11 +308,8 @@ public class MethodDefinition
             ParameterizedType returnType,
             List<ParameterizedType> parameterTypes)
     {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(");
-        Joiner.on("").appendTo(sb, parameterTypes);
-        sb.append(")");
-        sb.append(returnType);
-        return sb.toString();
+        return parameterTypes.stream()
+                .map(ParameterizedType::toString)
+                .collect(joining("", "(", ")")) + returnType;
     }
 }

--- a/src/main/java/io/airlift/bytecode/MethodDefinition.java
+++ b/src/main/java/io/airlift/bytecode/MethodDefinition.java
@@ -22,8 +22,6 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.InsnNode;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -39,7 +37,6 @@ import static java.util.stream.Collectors.joining;
 import static org.objectweb.asm.Opcodes.RETURN;
 
 @SuppressWarnings("UnusedDeclaration")
-@NotThreadSafe
 public class MethodDefinition
 {
     private final Scope scope;

--- a/src/main/java/io/airlift/bytecode/MethodDefinition.java
+++ b/src/main/java/io/airlift/bytecode/MethodDefinition.java
@@ -84,7 +84,7 @@ public class MethodDefinition
         this.parameters = ImmutableList.copyOf(parameters);
         this.parameterTypes = Lists.transform(this.parameters, Parameter::getType);
         this.parameterAnnotations = Streams.stream(parameters)
-                .map(input -> new ArrayList<AnnotationDefinition>())
+                .map(_ -> new ArrayList<AnnotationDefinition>())
                 .collect(toImmutableList());
         Optional<ParameterizedType> thisType = Optional.empty();
         if (!declaringClass.isInterface() && !access.contains(STATIC)) {
@@ -146,7 +146,7 @@ public class MethodDefinition
 
     public MethodDefinition comment(String format, Object... args)
     {
-        this.comment = String.format(format, args);
+        this.comment = format.formatted(args);
         return this;
     }
 
@@ -218,7 +218,8 @@ public class MethodDefinition
             exceptions[i] = this.exceptions.get(i).getClassName();
         }
 
-        MethodVisitor methodVisitor = visitor.visitMethod(toAccessModifier(access),
+        MethodVisitor methodVisitor = visitor.visitMethod(
+                toAccessModifier(access),
                 name,
                 getMethodDescriptor(),
                 genericMethodSignature(returnType, parameterTypes),

--- a/src/main/java/io/airlift/bytecode/Parameter.java
+++ b/src/main/java/io/airlift/bytecode/Parameter.java
@@ -13,7 +13,7 @@
  */
 package io.airlift.bytecode;
 
-import javax.annotation.concurrent.Immutable;
+import com.google.errorprone.annotations.Immutable;
 
 @Immutable
 public class Parameter

--- a/src/main/java/io/airlift/bytecode/ParameterizedType.java
+++ b/src/main/java/io/airlift/bytecode/ParameterizedType.java
@@ -14,10 +14,9 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
+import jakarta.annotation.Nullable;
 import org.objectweb.asm.Type;
-
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 

--- a/src/main/java/io/airlift/bytecode/Scope.java
+++ b/src/main/java/io/airlift/bytecode/Scope.java
@@ -90,7 +90,7 @@ public class Scope
     {
         requireNonNull(tempVariable, "tempVariable is null");
         checkArgument(tempVariable == tempVariables.get(tempVariable.getName()), "invalid tempVariable release: %s", tempVariable);
-        releasedTempVariables.computeIfAbsent(tempVariable.getType(), ignored -> new LinkedList<>()).push(tempVariable);
+        releasedTempVariables.computeIfAbsent(tempVariable.getType(), _ -> new LinkedList<>()).push(tempVariable);
     }
 
     public Variable getTempVariable(String name)

--- a/src/main/java/io/airlift/bytecode/control/CaseStatement.java
+++ b/src/main/java/io/airlift/bytecode/control/CaseStatement.java
@@ -13,10 +13,9 @@
  */
 package io.airlift.bytecode.control;
 
+import com.google.errorprone.annotations.Immutable;
 import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.instruction.LabelNode;
-
-import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 

--- a/src/main/java/io/airlift/bytecode/control/DoWhileLoop.java
+++ b/src/main/java/io/airlift/bytecode/control/DoWhileLoop.java
@@ -43,7 +43,7 @@ public class DoWhileLoop
 
     public DoWhileLoop(String format, Object... args)
     {
-        this.comment = String.format(format, args);
+        this.comment = format.formatted(args);
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/control/ForLoop.java
+++ b/src/main/java/io/airlift/bytecode/control/ForLoop.java
@@ -45,7 +45,7 @@ public class ForLoop
 
     public ForLoop(String format, Object... args)
     {
-        this.comment = String.format(format, args);
+        this.comment = format.formatted(args);
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/control/IfStatement.java
+++ b/src/main/java/io/airlift/bytecode/control/IfStatement.java
@@ -43,7 +43,7 @@ public class IfStatement
 
     public IfStatement(String format, Object... args)
     {
-        this.comment = String.format(format, args);
+        this.comment = format.formatted(args);
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/control/SwitchStatement.java
+++ b/src/main/java/io/airlift/bytecode/control/SwitchStatement.java
@@ -151,7 +151,7 @@ public class SwitchStatement
 
         public SwitchBuilder comment(String format, Object... args)
         {
-            this.comment = String.format(format, args);
+            this.comment = format.formatted(args);
             return this;
         }
 

--- a/src/main/java/io/airlift/bytecode/control/TryCatch.java
+++ b/src/main/java/io/airlift/bytecode/control/TryCatch.java
@@ -119,8 +119,8 @@ public class TryCatch
     public List<BytecodeNode> getChildNodes()
     {
         return Stream.concat(
-                Stream.of(tryNode),
-                catchBlocks.stream().map(CatchBlock::getHandler))
+                        Stream.of(tryNode),
+                        catchBlocks.stream().map(CatchBlock::getHandler))
                 .collect(toImmutableList());
     }
 

--- a/src/main/java/io/airlift/bytecode/control/WhileLoop.java
+++ b/src/main/java/io/airlift/bytecode/control/WhileLoop.java
@@ -42,7 +42,7 @@ public class WhileLoop
 
     public WhileLoop(String format, Object... args)
     {
-        this.comment = String.format(format, args);
+        this.comment = format.formatted(args);
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/debug/DebugNode.java
+++ b/src/main/java/io/airlift/bytecode/debug/DebugNode.java
@@ -16,6 +16,4 @@ package io.airlift.bytecode.debug;
 import io.airlift.bytecode.BytecodeNode;
 
 public interface DebugNode
-        extends BytecodeNode
-{
-}
+        extends BytecodeNode {}

--- a/src/main/java/io/airlift/bytecode/debug/LocalVariableNode.java
+++ b/src/main/java/io/airlift/bytecode/debug/LocalVariableNode.java
@@ -42,7 +42,8 @@ public class LocalVariableNode
     @Override
     public void accept(MethodVisitor visitor, MethodGenerationContext generationContext)
     {
-        visitor.visitLocalVariable(variable.getName(),
+        visitor.visitLocalVariable(
+                variable.getName(),
                 variable.getType().getType(),
                 variable.getType().getGenericSignature(),
                 start.getLabel(),

--- a/src/main/java/io/airlift/bytecode/expression/ArithmeticBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/ArithmeticBytecodeExpression.java
@@ -42,62 +42,38 @@ public class ArithmeticBytecodeExpression
 
     private static String getName(OpCode baseOpCode)
     {
-        switch (baseOpCode) {
-            case IAND:
-                return "Bitwise AND";
-            case IOR:
-                return "Bitwise OR";
-            case IXOR:
-                return "Bitwise XOR";
-            case IADD:
-                return "Add";
-            case ISUB:
-                return "Subtract";
-            case IMUL:
-                return "Multiply";
-            case IDIV:
-                return "Divide";
-            case IREM:
-                return "Remainder";
-            case ISHL:
-                return "Shift left";
-            case ISHR:
-                return "Shift right";
-            case IUSHR:
-                return "Shift right unsigned";
-            default:
-                throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
-        }
+        return switch (baseOpCode) {
+            case IAND -> "Bitwise AND";
+            case IOR -> "Bitwise OR";
+            case IXOR -> "Bitwise XOR";
+            case IADD -> "Add";
+            case ISUB -> "Subtract";
+            case IMUL -> "Multiply";
+            case IDIV -> "Divide";
+            case IREM -> "Remainder";
+            case ISHL -> "Shift left";
+            case ISHR -> "Shift right";
+            case IUSHR -> "Shift right unsigned";
+            default -> throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
+        };
     }
 
     private static String getInfixSymbol(OpCode baseOpCode)
     {
-        switch (baseOpCode) {
-            case IAND:
-                return "&";
-            case IOR:
-                return "|";
-            case IXOR:
-                return "^";
-            case IADD:
-                return "+";
-            case ISUB:
-                return "-";
-            case IMUL:
-                return "*";
-            case IDIV:
-                return "/";
-            case IREM:
-                return "%";
-            case ISHL:
-                return "<<";
-            case ISHR:
-                return ">>";
-            case IUSHR:
-                return ">>>";
-            default:
-                throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
-        }
+        return switch (baseOpCode) {
+            case IAND -> "&";
+            case IOR -> "|";
+            case IXOR -> "^";
+            case IADD -> "+";
+            case ISUB -> "-";
+            case IMUL -> "*";
+            case IDIV -> "/";
+            case IREM -> "%";
+            case ISHL -> "<<";
+            case ISHR -> ">>";
+            case IUSHR -> ">>>";
+            default -> throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
+        };
     }
 
     private static void checkArgumentTypes(OpCode baseOpCode, String name, BytecodeExpression left, BytecodeExpression right)
@@ -105,31 +81,22 @@ public class ArithmeticBytecodeExpression
         Class<?> leftType = getPrimitiveType(left, "left");
         Class<?> rightType = getPrimitiveType(right, "right");
         switch (baseOpCode) {
-            case IAND:
-            case IOR:
-            case IXOR:
+            case IAND, IOR, IXOR -> {
                 checkArgument(leftType == rightType, "left and right must be the same type");
                 checkArgument(leftType == int.class || leftType == long.class, "%s argument must be int or long, but is %s", name, leftType);
-                return;
-            case IADD:
-            case ISUB:
-            case IMUL:
-            case IDIV:
-            case IREM:
+            }
+            case IADD, ISUB, IMUL, IDIV, IREM -> {
                 checkArgument(leftType == rightType, "left and right must be the same type");
                 checkArgument(leftType == int.class || leftType == long.class || leftType == float.class || leftType == double.class,
                         "%s argument must be int, long, float, or double, but is %s",
                         name,
                         leftType);
-                return;
-            case ISHL:
-            case ISHR:
-            case IUSHR:
+            }
+            case ISHL, ISHR, IUSHR -> {
                 checkArgument(leftType == int.class || leftType == long.class, "%s left argument be int or long, but is %s", name, leftType);
                 checkArgument(rightType == int.class, "%s right argument be and int, but is %s", name, rightType);
-                return;
-            default:
-                throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
+            }
+            default -> throw new IllegalArgumentException("Unsupported OpCode " + baseOpCode);
         }
     }
 

--- a/src/main/java/io/airlift/bytecode/expression/BytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/BytecodeExpression.java
@@ -161,7 +161,8 @@ public abstract class BytecodeExpression
     {
         requireNonNull(parameters, "parameters is null");
 
-        return invoke(methodName,
+        return invoke(
+                methodName,
                 returnType,
                 Streams.stream(parameters).map(BytecodeExpression::getType).collect(toImmutableList()),
                 parameters);

--- a/src/main/java/io/airlift/bytecode/expression/BytecodeExpressions.java
+++ b/src/main/java/io/airlift/bytecode/expression/BytecodeExpressions.java
@@ -97,25 +97,15 @@ public final class BytecodeExpressions
 
     public static BytecodeExpression constantNumber(Number value)
     {
-        if (value instanceof Byte) {
-            return constantInt((value).intValue()).cast(byte.class);
-        }
-        if (value instanceof Short) {
-            return constantInt((value).intValue()).cast(short.class);
-        }
-        if (value instanceof Integer) {
-            return constantInt((Integer) value);
-        }
-        if (value instanceof Long) {
-            return constantLong((Long) value);
-        }
-        if (value instanceof Float) {
-            return constantFloat((Float) value);
-        }
-        if (value instanceof Double) {
-            return constantDouble((Double) value);
-        }
-        throw new IllegalArgumentException("Unsupported number type: " + value.getClass().getName());
+        return switch (value) {
+            case Byte byteValue -> constantInt(byteValue.intValue()).cast(byte.class);
+            case Short shortValue -> constantInt(shortValue.intValue()).cast(short.class);
+            case Integer integerValue -> constantInt(integerValue);
+            case Long longValue -> constantLong(longValue);
+            case Float floatValue -> constantFloat(floatValue);
+            case Double doubleValue -> constantDouble(doubleValue);
+            default -> throw new IllegalArgumentException("Unsupported number type: " + value.getClass().getName());
+        };
     }
 
     public static BytecodeExpression constantNull(Class<?> type)

--- a/src/main/java/io/airlift/bytecode/expression/CastBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/CastBytecodeExpression.java
@@ -25,7 +25,6 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.primitives.Primitives.wrap;
 import static io.airlift.bytecode.ParameterizedType.type;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 class CastBytecodeExpression
@@ -60,46 +59,42 @@ class CastBytecodeExpression
     {
         BytecodeBlock block = new BytecodeBlock();
 
-        switch (getTypeKind(sourceType)) {
-            case PRIMITIVE:
-                switch (getTypeKind(targetType)) {
-                    case PRIMITIVE:
-                        castPrimitiveToPrimitive(block, sourceType.getPrimitiveType(), targetType.getPrimitiveType());
-                        return block;
-                    case BOXED_PRIMITVE:
-                        checkArgument(sourceType.getPrimitiveType() == unwrapPrimitiveType(targetType), "Type %s can not be cast to %s", sourceType, targetType);
-                        return block.invokeStatic(targetType, "valueOf", targetType, sourceType);
-                    case OTHER:
-                        checkArgument(OBJECT_TYPE.equals(targetType), "Type %s can not be cast to %s", sourceType, targetType);
-                        Class<?> sourceClass = sourceType.getPrimitiveType();
-                        return block
-                                .invokeStatic(wrap(sourceClass), "valueOf", wrap(sourceClass), sourceClass)
-                                .checkCast(targetType);
+        return switch (getTypeKind(sourceType)) {
+            case PRIMITIVE -> switch (getTypeKind(targetType)) {
+                case PRIMITIVE -> castPrimitiveToPrimitive(block, sourceType.getPrimitiveType(), targetType.getPrimitiveType());
+                case BOXED_PRIMITVE -> {
+                    checkArgument(sourceType.getPrimitiveType() == unwrapPrimitiveType(targetType), "Type %s can not be cast to %s", sourceType, targetType);
+                    yield block.invokeStatic(targetType, "valueOf", targetType, sourceType);
                 }
-            case BOXED_PRIMITVE:
-                switch (getTypeKind(targetType)) {
-                    case PRIMITIVE:
-                        checkArgument(unwrapPrimitiveType(sourceType) == targetType.getPrimitiveType(), "Type %s can not be cast to %s", sourceType, targetType);
-                        return block.invokeVirtual(sourceType, targetType.getPrimitiveType().getSimpleName() + "Value", targetType);
-                    case BOXED_PRIMITVE:
-                        checkArgument(sourceType.equals(targetType), "Type %s can not be cast to %s", sourceType, targetType);
-                        return block;
-                    case OTHER:
-                        return block.checkCast(targetType);
+                case OTHER -> {
+                    checkArgument(OBJECT_TYPE.equals(targetType), "Type %s can not be cast to %s", sourceType, targetType);
+                    Class<?> sourceClass = sourceType.getPrimitiveType();
+                    yield block
+                            .invokeStatic(wrap(sourceClass), "valueOf", wrap(sourceClass), sourceClass)
+                            .checkCast(targetType);
                 }
-            case OTHER:
-                switch (getTypeKind(targetType)) {
-                    case PRIMITIVE:
-                        checkArgument(OBJECT_TYPE.equals(sourceType), "Type %s can not be cast to %s", sourceType, targetType);
-                        return block
-                                .checkCast(wrap(targetType.getPrimitiveType()))
-                                .invokeVirtual(wrap(targetType.getPrimitiveType()), targetType.getPrimitiveType().getSimpleName() + "Value", targetType.getPrimitiveType());
-                    case BOXED_PRIMITVE:
-                    case OTHER:
-                        return block.checkCast(targetType);
+            };
+            case BOXED_PRIMITVE -> switch (getTypeKind(targetType)) {
+                case PRIMITIVE -> {
+                    checkArgument(unwrapPrimitiveType(sourceType) == targetType.getPrimitiveType(), "Type %s can not be cast to %s", sourceType, targetType);
+                    yield block.invokeVirtual(sourceType, targetType.getPrimitiveType().getSimpleName() + "Value", targetType);
                 }
-        }
-        throw new UnsupportedOperationException("unexpected enum value");
+                case BOXED_PRIMITVE -> {
+                    checkArgument(sourceType.equals(targetType), "Type %s can not be cast to %s", sourceType, targetType);
+                    yield block;
+                }
+                case OTHER -> block.checkCast(targetType);
+            };
+            case OTHER -> switch (getTypeKind(targetType)) {
+                case PRIMITIVE -> {
+                    checkArgument(OBJECT_TYPE.equals(sourceType), "Type %s can not be cast to %s", sourceType, targetType);
+                    yield block
+                            .checkCast(wrap(targetType.getPrimitiveType()))
+                            .invokeVirtual(wrap(targetType.getPrimitiveType()), targetType.getPrimitiveType().getSimpleName() + "Value", targetType.getPrimitiveType());
+                }
+                case BOXED_PRIMITVE, OTHER -> block.checkCast(targetType);
+            };
+        };
     }
 
     private static BytecodeBlock castPrimitiveToPrimitive(BytecodeBlock block, Class<?> sourceType, Class<?> targetType)
@@ -273,7 +268,7 @@ class CastBytecodeExpression
                 return block;
             }
         }
-        throw new IllegalArgumentException(format("Type %s can not be cast to %s", sourceType.getName(), targetType.getName()));
+        throw new IllegalArgumentException("Type %s can not be cast to %s".formatted(sourceType.getName(), targetType.getName()));
     }
 
     private static TypeKind getTypeKind(ParameterizedType type)
@@ -289,26 +284,17 @@ class CastBytecodeExpression
 
     private static Class<?> unwrapPrimitiveType(ParameterizedType boxedPrimitiveType)
     {
-        switch (boxedPrimitiveType.getJavaClassName()) {
-            case "java.lang.Boolean":
-                return boolean.class;
-            case "java.lang.Byte":
-                return byte.class;
-            case "java.lang.Character":
-                return char.class;
-            case "java.lang.Short":
-                return short.class;
-            case "java.lang.Integer":
-                return int.class;
-            case "java.lang.Long":
-                return long.class;
-            case "java.lang.Float":
-                return float.class;
-            case "java.lang.Double":
-                return double.class;
-            default:
-                return null;
-        }
+        return switch (boxedPrimitiveType.getJavaClassName()) {
+            case "java.lang.Boolean" -> boolean.class;
+            case "java.lang.Byte" -> byte.class;
+            case "java.lang.Character" -> char.class;
+            case "java.lang.Short" -> short.class;
+            case "java.lang.Integer" -> int.class;
+            case "java.lang.Long" -> long.class;
+            case "java.lang.Float" -> float.class;
+            case "java.lang.Double" -> double.class;
+            default -> null;
+        };
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/expression/ConstantBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/ConstantBytecodeExpression.java
@@ -53,20 +53,14 @@ class ConstantBytecodeExpression
 
     public static String renderConstant(Object value)
     {
-        if (value instanceof Long) {
-            return value + "L";
-        }
-        if (value instanceof Float) {
-            return value + "f";
-        }
-        if (value instanceof ParameterizedType) {
-            return ((ParameterizedType) value).getSimpleName() + ".class";
-        }
-        // todo escape string
-        if (value instanceof String) {
-            return "\"" + value + "\"";
-        }
-        return String.valueOf(value);
+        return switch (value) {
+            case Long longValue -> longValue + "L";
+            case Float floatValue -> floatValue + "f";
+            case ParameterizedType parameterizedType -> parameterizedType.getSimpleName() + ".class";
+            // todo escape string
+            case String string -> "\"" + string + "\"";
+            case null, default -> String.valueOf(value);
+        };
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/expression/GetFieldBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/GetFieldBytecodeExpression.java
@@ -30,7 +30,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.Access.STATIC;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.instruction.FieldInstruction.getStaticInstruction;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 class GetFieldBytecodeExpression
@@ -114,7 +113,7 @@ class GetFieldBytecodeExpression
             return declaringClass.getField(name);
         }
         catch (NoSuchFieldException e) {
-            throw new IllegalArgumentException(format("Class %s does not have a '%s' field", declaringClass.getName(), name));
+            throw new IllegalArgumentException("Class %s does not have a '%s' field".formatted(declaringClass.getName(), name));
         }
     }
 }

--- a/src/main/java/io/airlift/bytecode/expression/GetFieldBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/GetFieldBytecodeExpression.java
@@ -19,8 +19,7 @@ import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.FieldDefinition;
 import io.airlift.bytecode.MethodGenerationContext;
 import io.airlift.bytecode.ParameterizedType;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/src/main/java/io/airlift/bytecode/expression/InvokeBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/InvokeBytecodeExpression.java
@@ -18,8 +18,7 @@ import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.MethodGenerationContext;
 import io.airlift.bytecode.ParameterizedType;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 

--- a/src/main/java/io/airlift/bytecode/expression/InvokeBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/InvokeBytecodeExpression.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.bytecode.expression;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
@@ -26,6 +25,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 class InvokeBytecodeExpression
         extends BytecodeExpression
@@ -99,10 +99,10 @@ class InvokeBytecodeExpression
     protected String formatOneLine()
     {
         if (instance == null) {
-            return methodTargetType.getSimpleName() + "." + methodName + "(" + Joiner.on(", ").join(parameters) + ")";
+            return methodTargetType.getSimpleName() + "." + methodName + "(" + parameters.stream().map(Object::toString).collect(joining(", ")) + ")";
         }
 
-        return instance + "." + methodName + "(" + Joiner.on(", ").join(parameters) + ")";
+        return instance + "." + methodName + "(" + parameters.stream().map(Object::toString).collect(joining(", ")) + ")";
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/expression/InvokeDynamicBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/InvokeDynamicBytecodeExpression.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.bytecode.expression;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
@@ -79,7 +78,7 @@ class InvokeDynamicBytecodeExpression
         }
         builder.append("]=>");
 
-        builder.append(methodName).append("(").append(Joiner.on(", ").join(parameters)).append(")");
+        builder.append(methodName).append("(").append(parameters.stream().map(Object::toString).collect(Collectors.joining(", "))).append(")");
 
         return builder.toString();
     }

--- a/src/main/java/io/airlift/bytecode/expression/NewArrayBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/NewArrayBytecodeExpression.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.bytecode.expression;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
@@ -29,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.ArrayOpCode.getArrayOpCode;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 class NewArrayBytecodeExpression
         extends BytecodeExpression
@@ -97,7 +97,7 @@ class NewArrayBytecodeExpression
         if (elements == null) {
             return "new " + elementType.getSimpleName() + "[" + length + "]";
         }
-        return "new " + elementType.getSimpleName() + "[] {" + Joiner.on(", ").join(elements) + "}";
+        return "new " + elementType.getSimpleName() + "[] {" + elements.stream().map(Object::toString).collect(joining(", ")) + "}";
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/expression/NewArrayBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/NewArrayBytecodeExpression.java
@@ -19,8 +19,7 @@ import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.MethodGenerationContext;
 import io.airlift.bytecode.ParameterizedType;
 import io.airlift.bytecode.instruction.TypeInstruction;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 

--- a/src/main/java/io/airlift/bytecode/expression/NewInstanceBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/NewInstanceBytecodeExpression.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.bytecode.expression;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
@@ -23,6 +22,7 @@ import io.airlift.bytecode.ParameterizedType;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 class NewInstanceBytecodeExpression
         extends BytecodeExpression
@@ -56,7 +56,7 @@ class NewInstanceBytecodeExpression
     @Override
     protected String formatOneLine()
     {
-        return "new " + getType().getSimpleName() + "(" + Joiner.on(", ").join(parameters) + ")";
+        return "new " + getType().getSimpleName() + "(" + parameters.stream().map(Object::toString).collect(joining(", ")) + ")";
     }
 
     @Override

--- a/src/main/java/io/airlift/bytecode/expression/SetFieldBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/SetFieldBytecodeExpression.java
@@ -29,7 +29,6 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.Access.STATIC;
 import static io.airlift.bytecode.ParameterizedType.type;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 class SetFieldBytecodeExpression
@@ -75,7 +74,8 @@ class SetFieldBytecodeExpression
         this(instance, declaringClass, name, value, value.getType());
     }
 
-    public SetFieldBytecodeExpression(@Nullable BytecodeExpression instance,
+    public SetFieldBytecodeExpression(
+            @Nullable BytecodeExpression instance,
             ParameterizedType declaringClass,
             String name,
             BytecodeExpression value,
@@ -138,7 +138,7 @@ class SetFieldBytecodeExpression
             return declaringClass.getField(name);
         }
         catch (NoSuchFieldException e) {
-            throw new IllegalArgumentException(format("Class %s does not have a '%s' field", declaringClass.getName(), name));
+            throw new IllegalArgumentException("Class %s does not have a '%s' field".formatted(declaringClass.getName(), name));
         }
     }
 }

--- a/src/main/java/io/airlift/bytecode/expression/SetFieldBytecodeExpression.java
+++ b/src/main/java/io/airlift/bytecode/expression/SetFieldBytecodeExpression.java
@@ -19,8 +19,7 @@ import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.FieldDefinition;
 import io.airlift.bytecode.MethodGenerationContext;
 import io.airlift.bytecode.ParameterizedType;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/src/main/java/io/airlift/bytecode/instruction/Constant.java
+++ b/src/main/java/io/airlift/bytecode/instruction/Constant.java
@@ -52,7 +52,6 @@ import static io.airlift.bytecode.instruction.FieldInstruction.getStaticInstruct
 import static io.airlift.bytecode.instruction.InvokeInstruction.invokeStatic;
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("UnusedDeclaration")
 public abstract class Constant
         implements InstructionNode
 {

--- a/src/main/java/io/airlift/bytecode/instruction/Constant.java
+++ b/src/main/java/io/airlift/bytecode/instruction/Constant.java
@@ -114,25 +114,15 @@ public abstract class Constant
     public static Constant loadNumber(Number value)
     {
         requireNonNull(value, "value is null");
-        if (value instanceof Byte) {
-            return loadInt((value).intValue());
-        }
-        if (value instanceof Short) {
-            return loadInt((value).intValue());
-        }
-        if (value instanceof Integer) {
-            return loadInt((Integer) value);
-        }
-        if (value instanceof Long) {
-            return loadLong((Long) value);
-        }
-        if (value instanceof Float) {
-            return loadFloat((Float) value);
-        }
-        if (value instanceof Double) {
-            return loadDouble((Double) value);
-        }
-        throw new IllegalStateException("Unsupported number type " + value.getClass().getSimpleName());
+        return switch (value) {
+            case Byte byteValue -> loadInt(byteValue.intValue());
+            case Short shortValue -> loadInt(shortValue.intValue());
+            case Integer integerValue -> loadInt(integerValue);
+            case Long longValue -> loadLong(longValue);
+            case Float floatValue -> loadFloat(floatValue);
+            case Double doubleValue -> loadDouble(doubleValue);
+            default -> throw new IllegalStateException("Unsupported number type " + value.getClass().getSimpleName());
+        };
     }
 
     public static Constant loadString(String value)

--- a/src/main/java/io/airlift/bytecode/instruction/Constant.java
+++ b/src/main/java/io/airlift/bytecode/instruction/Constant.java
@@ -312,30 +312,14 @@ public abstract class Constant
         {
             if (value <= Byte.MAX_VALUE && value >= Byte.MIN_VALUE) {
                 switch (value) {
-                    case -1:
-                        visitor.visitInsn(ICONST_M1.getOpCode());
-                        break;
-                    case 0:
-                        visitor.visitInsn(ICONST_0.getOpCode());
-                        break;
-                    case 1:
-                        visitor.visitInsn(ICONST_1.getOpCode());
-                        break;
-                    case 2:
-                        visitor.visitInsn(ICONST_2.getOpCode());
-                        break;
-                    case 3:
-                        visitor.visitInsn(ICONST_3.getOpCode());
-                        break;
-                    case 4:
-                        visitor.visitInsn(ICONST_4.getOpCode());
-                        break;
-                    case 5:
-                        visitor.visitInsn(ICONST_5.getOpCode());
-                        break;
-                    default:
-                        visitor.visitIntInsn(BIPUSH.getOpCode(), value);
-                        break;
+                    case -1 -> visitor.visitInsn(ICONST_M1.getOpCode());
+                    case 0 -> visitor.visitInsn(ICONST_0.getOpCode());
+                    case 1 -> visitor.visitInsn(ICONST_1.getOpCode());
+                    case 2 -> visitor.visitInsn(ICONST_2.getOpCode());
+                    case 3 -> visitor.visitInsn(ICONST_3.getOpCode());
+                    case 4 -> visitor.visitInsn(ICONST_4.getOpCode());
+                    case 5 -> visitor.visitInsn(ICONST_5.getOpCode());
+                    default -> visitor.visitIntInsn(BIPUSH.getOpCode(), value);
                 }
             }
             else if (value <= Short.MAX_VALUE && value >= Short.MIN_VALUE) {

--- a/src/main/java/io/airlift/bytecode/instruction/InstructionNode.java
+++ b/src/main/java/io/airlift/bytecode/instruction/InstructionNode.java
@@ -16,6 +16,4 @@ package io.airlift.bytecode.instruction;
 import io.airlift.bytecode.BytecodeNode;
 
 public interface InstructionNode
-        extends BytecodeNode
-{
-}
+        extends BytecodeNode {}

--- a/src/main/java/io/airlift/bytecode/instruction/InvokeInstruction.java
+++ b/src/main/java/io/airlift/bytecode/instruction/InvokeInstruction.java
@@ -43,7 +43,6 @@ import static io.airlift.bytecode.OpCode.INVOKEVIRTUAL;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("UnusedDeclaration")
 public class InvokeInstruction
         implements InstructionNode
 {

--- a/src/main/java/io/airlift/bytecode/instruction/InvokeInstruction.java
+++ b/src/main/java/io/airlift/bytecode/instruction/InvokeInstruction.java
@@ -218,7 +218,8 @@ public class InvokeInstruction
 
     private static InstructionNode invoke(OpCode invocationType, Method method)
     {
-        return new InvokeInstruction(invocationType,
+        return new InvokeInstruction(
+                invocationType,
                 type(method.getDeclaringClass()),
                 method.getName(),
                 type(method.getReturnType()),
@@ -227,7 +228,8 @@ public class InvokeInstruction
 
     private static InstructionNode invoke(OpCode invocationType, MethodDefinition method)
     {
-        return new InvokeInstruction(invocationType,
+        return new InvokeInstruction(
+                invocationType,
                 method.getDeclaringClass().getType(),
                 method.getName(),
                 method.getReturnType(),
@@ -236,7 +238,8 @@ public class InvokeInstruction
 
     private static InstructionNode invoke(OpCode invocationType, ParameterizedType target, String name, ParameterizedType returnType, Iterable<ParameterizedType> parameterTypes)
     {
-        return new InvokeInstruction(invocationType,
+        return new InvokeInstruction(
+                invocationType,
                 target,
                 name,
                 returnType,
@@ -245,7 +248,8 @@ public class InvokeInstruction
 
     private static InstructionNode invoke(OpCode invocationType, Class<?> target, String name, Class<?> returnType, Iterable<Class<?>> parameterTypes)
     {
-        return new InvokeInstruction(invocationType,
+        return new InvokeInstruction(
+                invocationType,
                 type(target),
                 name,
                 type(returnType),
@@ -256,50 +260,58 @@ public class InvokeInstruction
     // Invoke Dynamic
     //
 
-    public static InstructionNode invokeDynamic(String name,
+    public static InstructionNode invokeDynamic(
+            String name,
             ParameterizedType returnType,
             Iterable<ParameterizedType> parameterTypes,
             Method bootstrapMethod,
             Iterable<Object> bootstrapArguments)
     {
-        return new InvokeDynamicInstruction(name,
+        return new InvokeDynamicInstruction(
+                name,
                 returnType,
                 parameterTypes,
                 bootstrapMethod,
                 ImmutableList.copyOf(bootstrapArguments));
     }
 
-    public static InstructionNode invokeDynamic(String name,
+    public static InstructionNode invokeDynamic(
+            String name,
             ParameterizedType returnType,
             Iterable<ParameterizedType> parameterTypes,
             Method bootstrapMethod,
             Object... bootstrapArguments)
     {
-        return new InvokeDynamicInstruction(name,
+        return new InvokeDynamicInstruction(
+                name,
                 returnType,
                 parameterTypes,
                 bootstrapMethod,
                 ImmutableList.copyOf(bootstrapArguments));
     }
 
-    public static InstructionNode invokeDynamic(String name,
+    public static InstructionNode invokeDynamic(
+            String name,
             MethodType methodType,
             Method bootstrapMethod,
             Iterable<Object> bootstrapArguments)
     {
-        return new InvokeDynamicInstruction(name,
+        return new InvokeDynamicInstruction(
+                name,
                 type(methodType.returnType()),
                 methodType.parameterList().stream().map(ParameterizedType::type).collect(toImmutableList()),
                 bootstrapMethod,
                 ImmutableList.copyOf(bootstrapArguments));
     }
 
-    public static InstructionNode invokeDynamic(String name,
+    public static InstructionNode invokeDynamic(
+            String name,
             MethodType methodType,
             Method bootstrapMethod,
             Object... bootstrapArguments)
     {
-        return new InvokeDynamicInstruction(name,
+        return new InvokeDynamicInstruction(
+                name,
                 type(methodType.returnType()),
                 methodType.parameterList().stream().map(ParameterizedType::type).collect(toImmutableList()),
                 bootstrapMethod,
@@ -312,7 +324,8 @@ public class InvokeInstruction
     private final ParameterizedType returnType;
     private final List<ParameterizedType> parameterTypes;
 
-    public InvokeInstruction(OpCode opCode,
+    public InvokeInstruction(
+            OpCode opCode,
             ParameterizedType target,
             String name,
             ParameterizedType returnType,
@@ -380,7 +393,8 @@ public class InvokeInstruction
         private final Method bootstrapMethod;
         private final List<Object> bootstrapArguments;
 
-        public InvokeDynamicInstruction(String name,
+        public InvokeDynamicInstruction(
+                String name,
                 ParameterizedType returnType,
                 Iterable<ParameterizedType> parameterTypes,
                 Method bootstrapMethod,
@@ -394,7 +408,8 @@ public class InvokeInstruction
         @Override
         public void accept(MethodVisitor visitor, MethodGenerationContext generationContext)
         {
-            Handle bootstrapMethodHandle = new Handle(Opcodes.H_INVOKESTATIC,
+            Handle bootstrapMethodHandle = new Handle(
+                    Opcodes.H_INVOKESTATIC,
                     type(bootstrapMethod.getDeclaringClass()).getClassName(),
                     bootstrapMethod.getName(),
                     methodDescription(
@@ -402,7 +417,8 @@ public class InvokeInstruction
                             bootstrapMethod.getParameterTypes()),
                     false);
 
-            visitor.visitInvokeDynamicInsn(getName(),
+            visitor.visitInvokeDynamicInsn(
+                    getName(),
                     getMethodDescription(),
                     bootstrapMethodHandle,
                     bootstrapArguments.toArray(new Object[0]));

--- a/src/main/java/io/airlift/bytecode/instruction/JumpInstruction.java
+++ b/src/main/java/io/airlift/bytecode/instruction/JumpInstruction.java
@@ -39,7 +39,6 @@ import static io.airlift.bytecode.OpCode.IF_ICMPLE;
 import static io.airlift.bytecode.OpCode.IF_ICMPLT;
 import static io.airlift.bytecode.OpCode.IF_ICMPNE;
 
-@SuppressWarnings("UnusedDeclaration")
 public class JumpInstruction
         implements InstructionNode
 {

--- a/src/main/java/io/airlift/bytecode/instruction/TypeInstruction.java
+++ b/src/main/java/io/airlift/bytecode/instruction/TypeInstruction.java
@@ -32,7 +32,6 @@ import static io.airlift.bytecode.OpCode.NEW;
 import static io.airlift.bytecode.OpCode.NEWARRAY;
 import static io.airlift.bytecode.ParameterizedType.type;
 
-@SuppressWarnings("UnusedDeclaration")
 public class TypeInstruction
         implements InstructionNode
 {

--- a/src/test/java/io/airlift/bytecode/TestAnnotationDefinition.java
+++ b/src/test/java/io/airlift/bytecode/TestAnnotationDefinition.java
@@ -73,9 +73,37 @@ class TestAnnotationDefinition
         assertThat(annotation.value()).containsExactly("a", "b");
     }
 
+    @Test
+    void testEnumAnnotationValue()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "test/EnumAnnotationExample",
+                type(Object.class));
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+        classDefinition.declareAnnotation(EnumValues.class)
+                .setValue("single", RetentionPolicy.CLASS)
+                .setValue("multiple", ImmutableList.of(RetentionPolicy.SOURCE, RetentionPolicy.RUNTIME));
+
+        Class<?> clazz = classGenerator(getClass().getClassLoader())
+                .defineClass(classDefinition, Object.class);
+
+        EnumValues annotation = clazz.getAnnotation(EnumValues.class);
+        assertThat(annotation.single()).isEqualTo(RetentionPolicy.CLASS);
+        assertThat(annotation.multiple()).containsExactly(RetentionPolicy.SOURCE, RetentionPolicy.RUNTIME);
+    }
+
     @Retention(RetentionPolicy.RUNTIME)
     public @interface StringValues
     {
         String[] value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface EnumValues
+    {
+        RetentionPolicy single();
+
+        RetentionPolicy[] multiple();
     }
 }

--- a/src/test/java/io/airlift/bytecode/TestAnnotationDefinition.java
+++ b/src/test/java/io/airlift/bytecode/TestAnnotationDefinition.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.ClassGenerator.classGenerator;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestAnnotationDefinition
+{
+    @Test
+    void testListValidation()
+    {
+        AnnotationDefinition annotation = new AnnotationDefinition(StringValues.class);
+
+        assertThatCode(() -> annotation.setValue("value", ImmutableList.of("a", "b")))
+                .doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> annotation.setValue("nested", ImmutableList.of(ImmutableList.of("a"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("List contains a nested list");
+
+        assertThatThrownBy(() -> annotation.setValue("invalid", ImmutableList.of(new Object())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("List contains invalid type");
+
+        List<String> withNull = new ArrayList<>();
+        withNull.add(null);
+        assertThatThrownBy(() -> annotation.setValue("null", withNull))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("List contains a null element");
+    }
+
+    @Test
+    void testListAnnotationValue()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "test/ListAnnotationExample",
+                type(Object.class));
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+        classDefinition.declareAnnotation(StringValues.class)
+                .setValue("value", ImmutableList.of("a", "b"));
+
+        Class<?> clazz = classGenerator(getClass().getClassLoader())
+                .defineClass(classDefinition, Object.class);
+
+        StringValues annotation = clazz.getAnnotation(StringValues.class);
+        assertThat(annotation.value()).containsExactly("a", "b");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface StringValues
+    {
+        String[] value();
+    }
+}

--- a/src/test/java/io/airlift/bytecode/TestMethodDefinition.java
+++ b/src/test/java/io/airlift/bytecode/TestMethodDefinition.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.STATIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestMethodDefinition
+{
+    @Test
+    void testToSourceString()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC),
+                "test/Example",
+                type(Object.class));
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC, STATIC),
+                "add",
+                type(int.class),
+                ImmutableList.of(arg("a", int.class), arg("b", int.class)));
+
+        assertThat(method.toSourceString()).isEqualTo("public static int add(int a, int b)");
+    }
+}

--- a/src/test/java/io/airlift/bytecode/expression/BytecodeExpressionAssertions.java
+++ b/src/test/java/io/airlift/bytecode/expression/BytecodeExpressionAssertions.java
@@ -79,7 +79,7 @@ public final class BytecodeExpressionAssertions
     public static void assertBytecodeNode(BytecodeNode node, ParameterizedType returnType, Object expected, Optional<ClassLoader> parentClassLoader)
             throws Exception
     {
-        assertThat(execute(context -> node, returnType, parentClassLoader)).isEqualTo(expected);
+        assertThat(execute(_ -> node, returnType, parentClassLoader)).isEqualTo(expected);
     }
 
     public static void assertBytecodeNode(Function<Scope, BytecodeNode> nodeGenerator, ParameterizedType returnType, Object expected)

--- a/src/test/java/io/airlift/bytecode/expression/TestCastBytecodeExpression.java
+++ b/src/test/java/io/airlift/bytecode/expression/TestCastBytecodeExpression.java
@@ -37,7 +37,8 @@ public class TestCastBytecodeExpression
     void testDownCastObject()
             throws Exception
     {
-        assertBytecodeExpression(getStatic(getClass(), "OBJECT_FIELD").cast(String.class).invoke("length", int.class),
+        assertBytecodeExpression(
+                getStatic(getClass(), "OBJECT_FIELD").cast(String.class).invoke("length", int.class),
                 ((String) OBJECT_FIELD).length(),
                 "((String) " + getClass().getSimpleName() + ".OBJECT_FIELD).length()");
     }


### PR DESCRIPTION
Split out of #22.

Mechanical modernization:
* Update to Airbase 395
* Use pattern matching for instanceof
* Replace jsr305 with jakarta.annotation and Error Prone annotations
* Replace remaining Joiner usages with stream joining
* Remove stale UnusedDeclaration suppressions

The first three commits are behavioral fixes kept separate from the mechanical changes, included here because the conversions rewrite the affected lines:
* Nested annotation value lists always failed validation (recursion used the outer list, and the element type check ran first); a null list element now also fails validation instead of throwing NullPointerException
* Enum annotation values never worked: validation rejected them (an enum constant's class is the enum type, not `Enum`), and `visitEnum` was passed the internal class name where the JVM requires a field descriptor
* The dumped method declaration was missing the method name

All three now have test coverage.