### PR TITLE
Improve class generation performance and footprint

### DIFF
--- a/src/main/java/io/airlift/bytecode/ByteCodeGenerator.java
+++ b/src/main/java/io/airlift/bytecode/ByteCodeGenerator.java
@@ -14,6 +14,7 @@
 package io.airlift.bytecode;
 
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.util.CheckClassAdapter;
 import org.objectweb.asm.util.Textifier;
@@ -36,6 +37,7 @@ import static java.util.Objects.requireNonNull;
 class ByteCodeGenerator
 {
     private final boolean fakeLineNumbers;
+    private final boolean omitDebugInfo;
     private final ClassLoader runAsmVerifierClassLoader;
     private final boolean dumpRawBytecode;
     private final Writer output;
@@ -43,17 +45,19 @@ class ByteCodeGenerator
 
     public static ByteCodeGenerator byteCodeGenerator()
     {
-        return new ByteCodeGenerator(false, null, false, nullWriter(), Optional.empty());
+        return new ByteCodeGenerator(false, false, null, false, nullWriter(), Optional.empty());
     }
 
     private ByteCodeGenerator(
             boolean fakeLineNumbers,
+            boolean omitDebugInfo,
             ClassLoader runAsmVerifierClassLoader,
             boolean dumpRawBytecode,
             Writer output,
             Optional<Path> dumpClassPath)
     {
         this.fakeLineNumbers = fakeLineNumbers;
+        this.omitDebugInfo = omitDebugInfo;
         this.runAsmVerifierClassLoader = runAsmVerifierClassLoader;
         this.dumpRawBytecode = dumpRawBytecode;
         this.output = requireNonNull(output, "output is null");
@@ -62,35 +66,49 @@ class ByteCodeGenerator
 
     public ByteCodeGenerator fakeLineNumbers(boolean fakeLineNumbers)
     {
-        return new ByteCodeGenerator(fakeLineNumbers, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+    }
+
+    public ByteCodeGenerator omitDebugInfo(boolean omitDebugInfo)
+    {
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
     }
 
     public ByteCodeGenerator runAsmVerifier(ClassLoader runAsmVerifierClassLoader)
     {
-        return new ByteCodeGenerator(fakeLineNumbers, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
     }
 
     public ByteCodeGenerator dumpRawBytecode(boolean dumpRawBytecode)
     {
-        return new ByteCodeGenerator(fakeLineNumbers, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
     }
 
     public ByteCodeGenerator outputTo(Writer output)
     {
-        return new ByteCodeGenerator(fakeLineNumbers, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
     }
 
     public ByteCodeGenerator dumpClassFilesTo(Optional<Path> dumpClassPath)
     {
-        return new ByteCodeGenerator(fakeLineNumbers, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
+        return new ByteCodeGenerator(fakeLineNumbers, omitDebugInfo, runAsmVerifierClassLoader, dumpRawBytecode, output, dumpClassPath);
     }
 
     public byte[] generateByteCode(ClassInfoLoader classInfoLoader, ClassDefinition classDefinition)
     {
         ClassWriter writer = new SmartClassWriter(classInfoLoader);
 
+        // omitting debug info takes precedence over fake line numbers, which would be stripped anyway
+        ClassVisitor visitor = writer;
+        if (omitDebugInfo) {
+            visitor = new OmitDebugInfoClassVisitor(visitor);
+        }
+        else if (fakeLineNumbers) {
+            visitor = new AddFakeLineNumberClassVisitor(visitor);
+        }
+
         try {
-            classDefinition.visit(fakeLineNumbers ? new AddFakeLineNumberClassVisitor(writer) : writer);
+            classDefinition.visit(visitor);
         }
         catch (IndexOutOfBoundsException | NegativeArraySizeException e) {
             StringWriter out = new StringWriter();

--- a/src/main/java/io/airlift/bytecode/ClassGenerator.java
+++ b/src/main/java/io/airlift/bytecode/ClassGenerator.java
@@ -60,6 +60,15 @@ public class ClassGenerator
         return new ClassGenerator(classLoader, byteCodeGenerator.fakeLineNumbers(fakeLineNumbers));
     }
 
+    /**
+     * Omit debug info (SourceFile, LineNumberTable, LocalVariableTable) from generated classes.
+     * Takes precedence over {@link #fakeLineNumbers}.
+     */
+    public ClassGenerator omitDebugInfo(boolean omitDebugInfo)
+    {
+        return new ClassGenerator(classLoader, byteCodeGenerator.omitDebugInfo(omitDebugInfo));
+    }
+
     public ClassGenerator runAsmVerifier(boolean runAsmVerifier)
     {
         return new ClassGenerator(classLoader, byteCodeGenerator.runAsmVerifier(runAsmVerifier ? classLoader : null));

--- a/src/main/java/io/airlift/bytecode/ClassInfo.java
+++ b/src/main/java/io/airlift/bytecode/ClassInfo.java
@@ -60,6 +60,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class ClassInfo
 {
+    private static final ParameterizedType OBJECT_TYPE = type(Object.class);
+
     private final ClassInfoLoader loader;
     private final ParameterizedType type;
     private final int access;
@@ -184,7 +186,7 @@ public class ClassInfo
             return true;
         }
 
-        if (that.isInterface() && getType().equals(type(Object.class))) {
+        if (that.isInterface() && getType().equals(OBJECT_TYPE)) {
             return true;
         }
 

--- a/src/main/java/io/airlift/bytecode/ClassInfoLoader.java
+++ b/src/main/java/io/airlift/bytecode/ClassInfoLoader.java
@@ -115,11 +115,18 @@ public class ClassInfoLoader
             classReader = new ClassReader(bytecode);
         }
         else {
-            // load class file from class loader
+            // resolve through the loader first: already loaded classes are a cheap
+            // lookup, while reading the class file parses the whole constant pool
+            Optional<Class<?>> clazz = loader.tryLoadClass(type);
+            if (clazz.isPresent()) {
+                return new ClassInfo(this, clazz.orElseThrow());
+            }
+
+            // fall back to reading the class file
             classReader = loader.createByteCodeClassReader(type)
                     .orElse(null);
             if (classReader == null) {
-                // load class directly and extract class info from loaded class
+                // load class directly to throw a descriptive exception
                 return new ClassInfo(this, loader.loadClass(type));
             }
         }
@@ -148,6 +155,8 @@ public class ClassInfoLoader
 
     private interface Loader
     {
+        Optional<Class<?>> tryLoadClass(ParameterizedType type);
+
         Optional<ClassReader> createByteCodeClassReader(ParameterizedType type);
 
         Class<?> loadClass(ParameterizedType type);
@@ -161,6 +170,17 @@ public class ClassInfoLoader
         public LookupLoader(Lookup lookup)
         {
             this.lookup = requireNonNull(lookup, "lookup is null");
+        }
+
+        @Override
+        public Optional<Class<?>> tryLoadClass(ParameterizedType type)
+        {
+            try {
+                return Optional.of(lookup.findClass(type.getJavaClassName()));
+            }
+            catch (ClassNotFoundException | IllegalAccessException ignored) {
+                return Optional.empty();
+            }
         }
 
         @Override
@@ -189,6 +209,19 @@ public class ClassInfoLoader
         public ClassLoaderLoader(ClassLoader classLoader)
         {
             this.classLoader = requireNonNull(classLoader, "classLoader is null");
+        }
+
+        @Override
+        public Optional<Class<?>> tryLoadClass(ParameterizedType type)
+        {
+            try {
+                // load without initializing: already loaded classes resolve
+                // without any class file access
+                return Optional.of(Class.forName(type.getJavaClassName(), false, classLoader));
+            }
+            catch (ClassNotFoundException | LinkageError ignored) {
+                return Optional.empty();
+            }
         }
 
         @Override

--- a/src/main/java/io/airlift/bytecode/ClassInfoLoader.java
+++ b/src/main/java/io/airlift/bytecode/ClassInfoLoader.java
@@ -46,7 +46,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.util.CheckClassAdapter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,7 +64,7 @@ public class ClassInfoLoader
         ClassNode classNode = new ClassNode();
         classDefinition.visit(classNode);
 
-        return new ClassInfoLoader(ImmutableMap.of(classDefinition.getType(), classNode), ImmutableMap.of(), new LookupLoader(lookup), true);
+        return new ClassInfoLoader(ImmutableMap.of(classDefinition.getType(), classNode), ImmutableMap.of(), new LookupLoader(lookup));
     }
 
     public static ClassInfoLoader createClassInfoLoader(Iterable<ClassDefinition> classDefinitions, ClassLoader classLoader)
@@ -76,21 +75,19 @@ public class ClassInfoLoader
             classDefinition.visit(classNode);
             classNodes.put(classDefinition.getType(), classNode);
         }
-        return new ClassInfoLoader(classNodes.build(), ImmutableMap.of(), new ClassLoaderLoader(classLoader), true);
+        return new ClassInfoLoader(classNodes.build(), ImmutableMap.of(), new ClassLoaderLoader(classLoader));
     }
 
     private final Map<ParameterizedType, ClassNode> classNodes;
     private final Map<ParameterizedType, byte[]> bytecodes;
     private final Loader loader;
     private final Map<ParameterizedType, ClassInfo> classInfoCache = new HashMap<>();
-    private final boolean loadMethodNodes;
 
-    private ClassInfoLoader(Map<ParameterizedType, ClassNode> classNodes, Map<ParameterizedType, byte[]> bytecodes, Loader loader, boolean loadMethodNodes)
+    private ClassInfoLoader(Map<ParameterizedType, ClassNode> classNodes, Map<ParameterizedType, byte[]> bytecodes, Loader loader)
     {
         this.classNodes = ImmutableMap.copyOf(classNodes);
         this.bytecodes = ImmutableMap.copyOf(bytecodes);
         this.loader = loader;
-        this.loadMethodNodes = loadMethodNodes;
     }
 
     public ClassInfo loadClassInfo(ParameterizedType type)
@@ -127,40 +124,26 @@ public class ClassInfoLoader
             }
         }
 
-        if (loadMethodNodes) {
-            // slower version that loads all operations
-            classNode = new ClassNode();
-            classReader.accept(new CheckClassAdapter(classNode, false), ClassReader.SKIP_DEBUG);
+        // only the header is needed: computing common superclasses for frames
+        // uses just the access flags, superclass, and interfaces
+        int header = classReader.header;
+        int access = classReader.readUnsignedShort(header);
 
-            return new ClassInfo(this, classNode);
+        char[] buf = new char[classReader.getMaxStringLength()];
+
+        // read super class name
+        String superClassName = classReader.readClass(header + 4, buf);
+        ParameterizedType superClass = superClassName == null ? null : typeFromPathName(superClassName);
+
+        // read each interface name
+        int interfaceCount = classReader.readUnsignedShort(header + 6);
+        ImmutableList.Builder<ParameterizedType> interfaces = ImmutableList.builder();
+        header += 8;
+        for (int i = 0; i < interfaceCount; ++i) {
+            interfaces.add(typeFromPathName(classReader.readClass(header, buf)));
+            header += 2;
         }
-        else {
-            // optimized version
-            int header = classReader.header;
-            int access = classReader.readUnsignedShort(header);
-
-            char[] buf = new char[2048];
-
-            // read super class name
-            int superClassIndex = classReader.getItem(classReader.readUnsignedShort(header + 4));
-            ParameterizedType superClass;
-            if (superClassIndex == 0) {
-                superClass = null;
-            }
-            else {
-                superClass = typeFromPathName(classReader.readUTF8(superClassIndex, buf));
-            }
-
-            // read each interface name
-            int interfaceCount = classReader.readUnsignedShort(header + 6);
-            ImmutableList.Builder<ParameterizedType> interfaces = ImmutableList.builder();
-            header += 8;
-            for (int i = 0; i < interfaceCount; ++i) {
-                interfaces.add(typeFromPathName(classReader.readClass(header, buf)));
-                header += 2;
-            }
-            return new ClassInfo(this, type, access, superClass, interfaces.build(), null);
-        }
+        return new ClassInfo(this, type, access, superClass, interfaces.build(), null);
     }
 
     private interface Loader

--- a/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
+++ b/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
@@ -43,6 +43,15 @@ public class HiddenClassGenerator
         return new HiddenClassGenerator(lookup, byteCodeGenerator.fakeLineNumbers(fakeLineNumbers));
     }
 
+    /**
+     * Omit debug info (SourceFile, LineNumberTable, LocalVariableTable) from generated classes.
+     * Takes precedence over {@link #fakeLineNumbers}.
+     */
+    public HiddenClassGenerator omitDebugInfo(boolean omitDebugInfo)
+    {
+        return new HiddenClassGenerator(lookup, byteCodeGenerator.omitDebugInfo(omitDebugInfo));
+    }
+
     public HiddenClassGenerator runAsmVerifier(boolean runAsmVerifier)
     {
         return new HiddenClassGenerator(lookup, byteCodeGenerator.runAsmVerifier(runAsmVerifier ? new LookupClassLoader(lookup) : null));

--- a/src/main/java/io/airlift/bytecode/OmitDebugInfoClassVisitor.java
+++ b/src/main/java/io/airlift/bytecode/OmitDebugInfoClassVisitor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import static org.objectweb.asm.Opcodes.ASM9;
+
+class OmitDebugInfoClassVisitor
+        extends ClassVisitor
+{
+    public OmitDebugInfoClassVisitor(ClassVisitor cv)
+    {
+        super(ASM9, cv);
+    }
+
+    @Override
+    public void visitSource(String source, String debug) {}
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+    {
+        return new OmitDebugInfoMethodVisitor(cv.visitMethod(access, name, desc, signature, exceptions));
+    }
+
+    private static class OmitDebugInfoMethodVisitor
+            extends MethodVisitor
+    {
+        public OmitDebugInfoMethodVisitor(MethodVisitor mv)
+        {
+            super(ASM9, mv);
+        }
+
+        @Override
+        public void visitLineNumber(int line, Label start) {}
+
+        @Override
+        public void visitLocalVariable(String name, String descriptor, String signature, Label start, Label end, int index) {}
+    }
+}

--- a/src/main/java/io/airlift/bytecode/OpCode.java
+++ b/src/main/java/io/airlift/bytecode/OpCode.java
@@ -14,12 +14,10 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.bytecode.instruction.InstructionNode;
 import org.objectweb.asm.MethodVisitor;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -230,19 +228,22 @@ public enum OpCode
     GOTO_W(200),
     JSR_W(201);
 
-    private static final Map<Integer, OpCode> OP_CODE_INDEX;
+    private static final OpCode[] OP_CODE_INDEX;
 
     static {
-        ImmutableMap.Builder<Integer, OpCode> builder = ImmutableMap.builder();
+        OpCode[] index = new OpCode[256];
         for (OpCode opCode : OpCode.values()) {
-            builder.put(opCode.getOpCode(), opCode);
+            index[opCode.getOpCode()] = opCode;
         }
-        OP_CODE_INDEX = builder.build();
+        OP_CODE_INDEX = index;
     }
 
     public static OpCode getOpCode(int opCode)
     {
-        OpCode value = OP_CODE_INDEX.get(opCode);
+        OpCode value = null;
+        if (opCode >= 0 && opCode < OP_CODE_INDEX.length) {
+            value = OP_CODE_INDEX[opCode];
+        }
         checkArgument(value != null, "Unknown opCode %s", opCode);
         return value;
     }

--- a/src/main/java/io/airlift/bytecode/ParameterizedType.java
+++ b/src/main/java/io/airlift/bytecode/ParameterizedType.java
@@ -14,11 +14,13 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import jakarta.annotation.Nullable;
 import org.objectweb.asm.Type;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -26,6 +28,37 @@ import static java.util.Objects.requireNonNull;
 @Immutable
 public class ParameterizedType
 {
+    private static final Map<Class<?>, ParameterizedType> COMMON_TYPES;
+
+    static {
+        ImmutableMap.Builder<Class<?>, ParameterizedType> builder = ImmutableMap.builder();
+        for (Class<?> clazz : ImmutableList.of(
+                void.class,
+                boolean.class,
+                byte.class,
+                char.class,
+                short.class,
+                int.class,
+                long.class,
+                float.class,
+                double.class,
+                Void.class,
+                Boolean.class,
+                Byte.class,
+                Character.class,
+                Short.class,
+                Integer.class,
+                Long.class,
+                Float.class,
+                Double.class,
+                Object.class,
+                String.class,
+                Number.class)) {
+            builder.put(clazz, new ParameterizedType(clazz));
+        }
+        COMMON_TYPES = builder.buildOrThrow();
+    }
+
     public static ParameterizedType typeFromJavaClassName(String className)
     {
         requireNonNull(className, "type is null");
@@ -47,6 +80,10 @@ public class ParameterizedType
     public static ParameterizedType type(Class<?> type)
     {
         requireNonNull(type, "type is null");
+        ParameterizedType commonType = COMMON_TYPES.get(type);
+        if (commonType != null) {
+            return commonType;
+        }
         return new ParameterizedType(type);
     }
 
@@ -72,6 +109,12 @@ public class ParameterizedType
     private final Class<?> primitiveType;
     @Nullable
     private final ParameterizedType arrayComponentType;
+
+    // caches of deterministic computations; the benign race is harmless
+    @Nullable
+    private String javaClassName;
+    @Nullable
+    private String genericSignature;
 
     public ParameterizedType(String className)
     {
@@ -145,7 +188,12 @@ public class ParameterizedType
 
     public String getJavaClassName()
     {
-        return className.replace('/', '.');
+        String javaClassName = this.javaClassName;
+        if (javaClassName == null) {
+            javaClassName = className.replace('/', '.');
+            this.javaClassName = javaClassName;
+        }
+        return javaClassName;
     }
 
     public String getSimpleName()
@@ -165,10 +213,20 @@ public class ParameterizedType
 
     public String getGenericSignature()
     {
-        StringBuilder sb = new StringBuilder();
+        String genericSignature = this.genericSignature;
+        if (genericSignature == null) {
+            genericSignature = computeGenericSignature();
+            this.genericSignature = genericSignature;
+        }
+        return genericSignature;
+    }
+
+    private String computeGenericSignature()
+    {
         if (primitiveType != null || arrayComponentType != null) {
             return type;
         }
+        StringBuilder sb = new StringBuilder();
         sb.append('L').append(className);
         if (!parameters.isEmpty()) {
             sb.append("<");

--- a/src/main/java/io/airlift/bytecode/ParameterizedType.java
+++ b/src/main/java/io/airlift/bytecode/ParameterizedType.java
@@ -313,79 +313,25 @@ public class ParameterizedType
         return n.getName().replace('.', '/');
     }
 
-    private static String toInternalIdentifier(Class<?> n)
+    private static String toInternalIdentifier(Class<?> clazz)
     {
-        if (n.isArray()) {
-            n = n.getComponentType();
-            if (n.isPrimitive()) {
-                if (n == Byte.TYPE) {
-                    return "[B";
-                }
-                else if (n == Boolean.TYPE) {
-                    return "[Z";
-                }
-                else if (n == Short.TYPE) {
-                    return "[S";
-                }
-                else if (n == Character.TYPE) {
-                    return "[C";
-                }
-                else if (n == Integer.TYPE) {
-                    return "[I";
-                }
-                else if (n == Float.TYPE) {
-                    return "[F";
-                }
-                else if (n == Double.TYPE) {
-                    return "[D";
-                }
-                else if (n == Long.TYPE) {
-                    return "[J";
-                }
-                else {
-                    throw new RuntimeException("Unrecognized type in compiler: " + n.getName());
-                }
-            }
-            else {
-                return "[" + toInternalIdentifier(n);
-            }
+        if (clazz.isArray()) {
+            return "[" + toInternalIdentifier(clazz.getComponentType());
         }
-        else {
-            if (n.isPrimitive()) {
-                if (n == Byte.TYPE) {
-                    return "B";
-                }
-                else if (n == Boolean.TYPE) {
-                    return "Z";
-                }
-                else if (n == Short.TYPE) {
-                    return "S";
-                }
-                else if (n == Character.TYPE) {
-                    return "C";
-                }
-                else if (n == Integer.TYPE) {
-                    return "I";
-                }
-                else if (n == Float.TYPE) {
-                    return "F";
-                }
-                else if (n == Double.TYPE) {
-                    return "D";
-                }
-                else if (n == Long.TYPE) {
-                    return "J";
-                }
-                else if (n == Void.TYPE) {
-                    return "V";
-                }
-                else {
-                    throw new RuntimeException("Unrecognized type in compiler: " + n.getName());
-                }
-            }
-            else {
-                return "L" + getPathName(n) + ";";
-            }
+        if (clazz.isPrimitive()) {
+            return switch (clazz.getName()) {
+                case "boolean" -> "Z";
+                case "byte" -> "B";
+                case "char" -> "C";
+                case "short" -> "S";
+                case "int" -> "I";
+                case "long" -> "J";
+                case "float" -> "F";
+                case "double" -> "D";
+                case "void" -> "V";
+                default -> throw new IllegalArgumentException("Unrecognized type in compiler: " + clazz.getName());
+            };
         }
+        return "L" + getPathName(clazz) + ";";
     }
 }

--- a/src/main/java/io/airlift/bytecode/Scope.java
+++ b/src/main/java/io/airlift/bytecode/Scope.java
@@ -16,10 +16,10 @@ package io.airlift.bytecode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.expression.BytecodeExpression;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -89,7 +89,7 @@ public class Scope
     {
         requireNonNull(tempVariable, "tempVariable is null");
         checkArgument(tempVariable == tempVariables.get(tempVariable.getName()), "invalid tempVariable release: %s", tempVariable);
-        releasedTempVariables.computeIfAbsent(tempVariable.getType(), _ -> new LinkedList<>()).push(tempVariable);
+        releasedTempVariables.computeIfAbsent(tempVariable.getType(), _ -> new ArrayDeque<>()).push(tempVariable);
     }
 
     public Variable getTempVariable(String name)

--- a/src/test/java/io/airlift/bytecode/TestClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestClassGenerator.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.Map;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -30,11 +31,46 @@ import static io.airlift.bytecode.ClassGenerator.classGenerator;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestClassGenerator
 {
+    @Test
+    void testDefineClasses()
+            throws Exception
+    {
+        ClassDefinition first = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "test/First",
+                type(Object.class));
+        first.declareDefaultConstructor(a(PUBLIC));
+
+        ClassDefinition second = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "test/Second",
+                type(Object.class));
+        second.declareDefaultConstructor(a(PUBLIC));
+
+        // the classes reference each other, so they can only be generated together
+        first.declareMethod(a(PUBLIC, STATIC), "createSecond", second.getType())
+                .getBody()
+                .append(newInstance(second.getType()).ret());
+        second.declareMethod(a(PUBLIC, STATIC), "createFirst", first.getType())
+                .getBody()
+                .append(newInstance(first.getType()).ret());
+
+        Map<String, Class<?>> classes = classGenerator(getClass().getClassLoader())
+                .defineClasses(ImmutableList.of(first, second));
+
+        assertThat(classes).containsOnlyKeys("test.First", "test.Second");
+        assertThat(classes.get("test.First").getMethod("createSecond").invoke(null))
+                .isInstanceOf(classes.get("test.Second"));
+        assertThat(classes.get("test.Second").getMethod("createFirst").invoke(null))
+                .isInstanceOf(classes.get("test.First"));
+    }
+
     @Test
     void testGenerator()
             throws Exception

--- a/src/test/java/io/airlift/bytecode/TestClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestClassGenerator.java
@@ -121,4 +121,62 @@ class TestClassGenerator
             deleteRecursively(tempDir, ALLOW_INSECURE);
         }
     }
+
+    @Test
+    void testOmitDebugInfo()
+            throws Exception
+    {
+        StringWriter control = new StringWriter();
+        Class<?> clazz = classGenerator(getClass().getClassLoader())
+                .runAsmVerifier(true)
+                .dumpRawBytecode(true)
+                .outputTo(control)
+                .defineClass(exampleWithDebugInfo(), Object.class);
+
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+        assertThat(control.toString())
+                .contains("compiled from: Example.java")
+                .contains("LINENUMBER 42")
+                .contains("LOCALVARIABLE sum I");
+
+        StringWriter stripped = new StringWriter();
+        clazz = classGenerator(getClass().getClassLoader())
+                .omitDebugInfo(true)
+                .runAsmVerifier(true)
+                .dumpRawBytecode(true)
+                .outputTo(stripped)
+                .defineClass(exampleWithDebugInfo(), Object.class);
+
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+        assertThat(stripped.toString())
+                .doesNotContain("compiled from")
+                .doesNotContain("LINENUMBER")
+                .doesNotContain("LOCALVARIABLE");
+    }
+
+    private static ClassDefinition exampleWithDebugInfo()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "test/DebugExample",
+                type(Object.class));
+        classDefinition.visitSource("Example.java", null);
+
+        Parameter argA = arg("a", int.class);
+        Parameter argB = arg("b", int.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC, STATIC),
+                "add",
+                type(int.class),
+                ImmutableList.of(argA, argB));
+
+        Variable sum = method.getScope().declareVariable(int.class, "sum");
+        method.getBody()
+                .visitLineNumber(42)
+                .append(sum.set(add(argA, argB)))
+                .append(sum.ret());
+
+        return classDefinition;
+    }
 }

--- a/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
@@ -222,4 +222,44 @@ class TestHiddenClassGenerator
             deleteRecursively(tempDir, ALLOW_INSECURE);
         }
     }
+
+    @Test
+    void testOmitDebugInfo()
+            throws Exception
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "io/airlift/bytecode/DebugExample",
+                type(Object.class));
+        classDefinition.visitSource("Example.java", null);
+
+        Parameter argA = arg("a", int.class);
+        Parameter argB = arg("b", int.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC, STATIC),
+                "add",
+                type(int.class),
+                ImmutableList.of(argA, argB));
+
+        Variable sum = method.getScope().declareVariable(int.class, "sum");
+        method.getBody()
+                .visitLineNumber(42)
+                .append(sum.set(add(argA, argB)))
+                .append(sum.ret());
+
+        StringWriter writer = new StringWriter();
+        Class<?> clazz = hiddenClassGenerator(lookup())
+                .omitDebugInfo(true)
+                .runAsmVerifier(true)
+                .dumpRawBytecode(true)
+                .outputTo(writer)
+                .defineHiddenClass(classDefinition, Object.class, Optional.empty());
+
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+        assertThat(writer.toString())
+                .doesNotContain("compiled from")
+                .doesNotContain("LINENUMBER")
+                .doesNotContain("LOCALVARIABLE");
+    }
 }

--- a/src/test/java/io/airlift/bytecode/TestParameterizedType.java
+++ b/src/test/java/io/airlift/bytecode/TestParameterizedType.java
@@ -40,4 +40,23 @@ class TestParameterizedType
         assertThat(type(long[].class).getSlotSize()).isEqualTo(1);
         assertThat(typeFromJavaClassName("java.lang.String").getSlotSize()).isEqualTo(1);
     }
+
+    @Test
+    void testTypeDescriptor()
+    {
+        assertThat(type(boolean.class).getType()).isEqualTo("Z");
+        assertThat(type(byte.class).getType()).isEqualTo("B");
+        assertThat(type(char.class).getType()).isEqualTo("C");
+        assertThat(type(short.class).getType()).isEqualTo("S");
+        assertThat(type(int.class).getType()).isEqualTo("I");
+        assertThat(type(long.class).getType()).isEqualTo("J");
+        assertThat(type(float.class).getType()).isEqualTo("F");
+        assertThat(type(double.class).getType()).isEqualTo("D");
+        assertThat(type(void.class).getType()).isEqualTo("V");
+
+        assertThat(type(Object.class).getType()).isEqualTo("Ljava/lang/Object;");
+        assertThat(type(int[].class).getType()).isEqualTo("[I");
+        assertThat(type(long[][].class).getType()).isEqualTo("[[J");
+        assertThat(type(String[].class).getType()).isEqualTo("[Ljava/lang/String;");
+    }
 }


### PR DESCRIPTION
Split out of #22.

Performance and footprint improvements to class generation:
* Read only class file headers when loading class info
* Reduce allocations in ParameterizedType
* Use array lookup for opcodes
* Resolve dependency classes through the class loader first
* Add missing test coverage for batch class generation
* Simplify internal type descriptor construction
* Use ArrayDeque for released temporary variables
* Add option to omit debug info from generated classes (distinct commit): `ClassGenerator`/`HiddenClassGenerator` gain `omitDebugInfo(boolean)`, dropping SourceFile/LineNumberTable/LocalVariableTable from every generated class — production servers never look at them; enable dumping-friendly output by leaving it off