### PR TITLE
Add class data expressions and ClassDataBinder

### DIFF
--- a/src/main/java/io/airlift/bytecode/ClassDataBinder.java
+++ b/src/main/java/io/airlift/bytecode/ClassDataBinder.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.expression.BytecodeExpression;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassDataAt;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Collects runtime objects referenced by generated code and binds each one as
+ * a class data constant of a hidden class. Each bound object is loaded with a
+ * dynamic constant that is resolved once and then folded by the JIT.
+ *
+ * <pre>{@code
+ * ClassDataBinder binder = new ClassDataBinder();
+ *
+ * method.getBody()
+ *         .append(binder.bind(methodHandle, MethodHandle.class)
+ *                 .invoke("invokeExact", long.class, argument)
+ *                 .ret());
+ *
+ * hiddenClassGenerator(lookup)
+ *         .defineHiddenClass(classDefinition, superType, Optional.of(binder.getBindings()));
+ * }</pre>
+ *
+ * Bindings are deduplicated by identity: binding the same object again reuses
+ * its class data slot, while objects that are merely equal stay separate.
+ */
+public final class ClassDataBinder
+{
+    private final List<Object> bindings = new ArrayList<>();
+    private final Map<Object, Integer> bindingIndexes = new IdentityHashMap<>();
+
+    public BytecodeExpression bind(Object constant, Class<?> type)
+    {
+        return bind(constant, type(type));
+    }
+
+    public BytecodeExpression bind(Object constant, ParameterizedType type)
+    {
+        requireNonNull(constant, "constant is null");
+        requireNonNull(type, "type is null");
+
+        Integer index = bindingIndexes.get(constant);
+        if (index == null) {
+            index = bindings.size();
+            bindings.add(constant);
+            bindingIndexes.put(constant, index);
+        }
+        return constantClassDataAt(index, type);
+    }
+
+    /**
+     * The bound objects, to be passed as the class data when defining the hidden class.
+     */
+    public List<Object> getBindings()
+    {
+        return ImmutableList.copyOf(bindings);
+    }
+}

--- a/src/main/java/io/airlift/bytecode/ClassDataBinder.java
+++ b/src/main/java/io/airlift/bytecode/ClassDataBinder.java
@@ -16,11 +16,14 @@ package io.airlift.bytecode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.expression.BytecodeExpression;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassDataAt;
 import static java.util.Objects.requireNonNull;
@@ -34,12 +37,12 @@ import static java.util.Objects.requireNonNull;
  * ClassDataBinder binder = new ClassDataBinder();
  *
  * method.getBody()
- *         .append(binder.bind(methodHandle, MethodHandle.class)
- *                 .invoke("invokeExact", long.class, argument)
+ *         .append(binder.bindHandle(methodHandle)
+ *                 .invoke(argument)
  *                 .ret());
  *
  * hiddenClassGenerator(lookup)
- *         .defineHiddenClass(classDefinition, superType, Optional.of(binder.getBindings()));
+ *         .defineHiddenClass(classDefinition, superType, binder);
  * }</pre>
  *
  * Bindings are deduplicated by identity: binding the same object again reuses
@@ -70,10 +73,69 @@ public final class ClassDataBinder
     }
 
     /**
+     * Binds a method handle to be invoked exactly by the generated code.
+     */
+    public BoundMethodHandle bindHandle(MethodHandle handle)
+    {
+        requireNonNull(handle, "handle is null");
+        return new BoundMethodHandle(bind(handle, MethodHandle.class), handle.type());
+    }
+
+    /**
      * The bound objects, to be passed as the class data when defining the hidden class.
      */
     public List<Object> getBindings()
     {
         return ImmutableList.copyOf(bindings);
+    }
+
+    /**
+     * A method handle bound as a class data constant.
+     */
+    public static final class BoundMethodHandle
+    {
+        private final BytecodeExpression handle;
+        private final MethodType type;
+
+        private BoundMethodHandle(BytecodeExpression handle, MethodType type)
+        {
+            this.handle = handle;
+            this.type = type;
+        }
+
+        public MethodType type()
+        {
+            return type;
+        }
+
+        /**
+         * Loads the bound method handle, for callers that must place it on the stack
+         * themselves, e.g. below arguments that are already being pushed.
+         */
+        public BytecodeExpression handle()
+        {
+            return handle;
+        }
+
+        public BytecodeExpression invoke(BytecodeExpression... arguments)
+        {
+            return invoke(ImmutableList.copyOf(arguments));
+        }
+
+        /**
+         * Invokes the bound method handle exactly with the given arguments. The
+         * argument types must match the handle type exactly, as the invocation
+         * does not adapt arguments.
+         */
+        public BytecodeExpression invoke(List<BytecodeExpression> arguments)
+        {
+            checkArgument(arguments.size() == type.parameterCount(), "Expected %s arguments, but got %s", type.parameterCount(), arguments.size());
+            for (int i = 0; i < arguments.size(); i++) {
+                ParameterizedType expected = ParameterizedType.type(type.parameterType(i));
+                ParameterizedType actual = arguments.get(i).getType();
+                checkArgument(expected.equals(actual), "Expected argument %s to have type %s, but got %s", i, expected, actual);
+            }
+            return handle.invoke("invokeExact", type.returnType(), arguments);
+        }
     }
 }

--- a/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
+++ b/src/main/java/io/airlift/bytecode/HiddenClassGenerator.java
@@ -16,9 +16,11 @@ package io.airlift.bytecode;
 import java.io.Writer;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.bytecode.ClassInfoLoader.createClassInfoLoader;
+import static java.util.Objects.requireNonNull;
 
 public class HiddenClassGenerator
 {
@@ -64,6 +66,17 @@ public class HiddenClassGenerator
     public HiddenClassGenerator dumpClassFilesTo(Optional<Path> dumpClassPath)
     {
         return new HiddenClassGenerator(lookup, byteCodeGenerator.dumpClassFilesTo(dumpClassPath));
+    }
+
+    /**
+     * Defines the class with the binder's bound objects as its class data. A binder
+     * with no bindings defines the class without class data.
+     */
+    public <T> Class<? extends T> defineHiddenClass(ClassDefinition classDefinition, Class<T> superType, ClassDataBinder binder)
+    {
+        requireNonNull(binder, "binder is null");
+        List<Object> bindings = binder.getBindings();
+        return defineHiddenClass(classDefinition, superType, bindings.isEmpty() ? Optional.empty() : Optional.of(bindings));
     }
 
     public <T> Class<? extends T> defineHiddenClass(ClassDefinition classDefinition, Class<T> superType, Optional<Object> classData)

--- a/src/main/java/io/airlift/bytecode/expression/BytecodeExpressions.java
+++ b/src/main/java/io/airlift/bytecode/expression/BytecodeExpressions.java
@@ -19,6 +19,8 @@ import io.airlift.bytecode.MethodDefinition;
 import io.airlift.bytecode.OpCode;
 import io.airlift.bytecode.ParameterizedType;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -44,6 +46,22 @@ import static java.util.Objects.requireNonNull;
 
 public final class BytecodeExpressions
 {
+    // condy name required by the MethodHandles.classData bootstraps (ConstantDescs.DEFAULT_NAME)
+    private static final String DEFAULT_NAME = "_";
+
+    private static final Method CLASS_DATA_BOOTSTRAP;
+    private static final Method CLASS_DATA_AT_BOOTSTRAP;
+
+    static {
+        try {
+            CLASS_DATA_BOOTSTRAP = MethodHandles.class.getMethod("classData", Lookup.class, String.class, Class.class);
+            CLASS_DATA_AT_BOOTSTRAP = MethodHandles.class.getMethod("classDataAt", Lookup.class, String.class, Class.class, int.class);
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private BytecodeExpressions() {}
 
     //
@@ -131,6 +149,37 @@ public final class BytecodeExpressions
     public static BytecodeExpression constantString(String value)
     {
         return new ConstantBytecodeExpression(String.class, loadString(value));
+    }
+
+    /**
+     * Loads the class data of a hidden class defined with
+     * {@code Lookup.defineHiddenClassWithClassData} as a dynamic constant.
+     * The constant is resolved once and treated as a true constant by the JIT.
+     */
+    public static BytecodeExpression constantClassData(Class<?> type)
+    {
+        return constantClassData(type(type));
+    }
+
+    public static BytecodeExpression constantClassData(ParameterizedType type)
+    {
+        return constantDynamic(DEFAULT_NAME, type, CLASS_DATA_BOOTSTRAP);
+    }
+
+    /**
+     * Loads an element of the class data list of a hidden class defined with
+     * {@code Lookup.defineHiddenClassWithClassData} as a dynamic constant.
+     * The constant is resolved once and treated as a true constant by the JIT.
+     */
+    public static BytecodeExpression constantClassDataAt(int index, Class<?> type)
+    {
+        return constantClassDataAt(index, type(type));
+    }
+
+    public static BytecodeExpression constantClassDataAt(int index, ParameterizedType type)
+    {
+        checkArgument(index >= 0, "index is negative");
+        return constantDynamic(DEFAULT_NAME, type, CLASS_DATA_AT_BOOTSTRAP, index);
     }
 
     public static BytecodeExpression constantDynamic(

--- a/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
@@ -17,8 +17,10 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -31,12 +33,54 @@ import static io.airlift.bytecode.HiddenClassGenerator.hiddenClassGenerator;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassData;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassDataAt;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestHiddenClassGenerator
 {
+    @Test
+    void testClassDataConstants()
+            throws Exception
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "io/airlift/bytecode/ClassDataExample",
+                type(Object.class));
+
+        // load the entire class data list
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "data", type(List.class))
+                .getBody()
+                .append(constantClassData(List.class).ret());
+
+        // load a single element of the class data
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "message", type(String.class))
+                .getBody()
+                .append(constantClassDataAt(0, String.class).ret());
+
+        // invoke a MethodHandle bound through the class data
+        Parameter argA = arg("a", int.class);
+        Parameter argB = arg("b", int.class);
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "add", type(int.class), ImmutableList.of(argA, argB))
+                .getBody()
+                .append(constantClassDataAt(1, MethodHandle.class)
+                        .invoke("invokeExact", int.class, argA, argB)
+                        .ret());
+
+        MethodHandle addExact = lookup().findStatic(Math.class, "addExact", methodType(int.class, int.class, int.class));
+        List<Object> classData = ImmutableList.of("hello", addExact);
+
+        Class<?> clazz = hiddenClassGenerator(lookup())
+                .defineHiddenClass(classDefinition, Object.class, Optional.of(classData));
+
+        assertThat(clazz.getMethod("data").invoke(null)).isSameAs(classData);
+        assertThat(clazz.getMethod("message").invoke(null)).isEqualTo("hello");
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+    }
+
     @Test
     void testGenerator()
             throws Exception

--- a/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
@@ -114,7 +114,7 @@ class TestHiddenClassGenerator
         assertThat(binder.getBindings()).containsExactly(message, addExact);
 
         Class<?> clazz = hiddenClassGenerator(lookup())
-                .defineHiddenClass(classDefinition, Object.class, Optional.of(binder.getBindings()));
+                .defineHiddenClass(classDefinition, Object.class, binder);
 
         assertThat(clazz.getMethod("message").invoke(null)).isSameAs(message);
         assertThat(clazz.getMethod("sameMessage").invoke(null)).isSameAs(message);

--- a/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
@@ -14,6 +14,7 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.ClassDataBinder.BoundMethodHandle;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
@@ -35,10 +36,12 @@ import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.add;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassData;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassDataAt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantString;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestHiddenClassGenerator
 {
@@ -119,6 +122,54 @@ class TestHiddenClassGenerator
         assertThat(clazz.getMethod("message").invoke(null)).isSameAs(message);
         assertThat(clazz.getMethod("sameMessage").invoke(null)).isSameAs(message);
         assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+    }
+
+    @Test
+    void testBoundMethodHandle()
+            throws Exception
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "io/airlift/bytecode/BoundHandleExample",
+                type(Object.class));
+
+        ClassDataBinder binder = new ClassDataBinder();
+        MethodHandle addExact = lookup().findStatic(Math.class, "addExact", methodType(int.class, int.class, int.class));
+
+        Parameter argA = arg("a", int.class);
+        Parameter argB = arg("b", int.class);
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "add", type(int.class), ImmutableList.of(argA, argB))
+                .getBody()
+                .append(binder.bindHandle(addExact).invoke(argA, argB).ret());
+
+        // binding the same handle again reuses its class data slot
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "addAgain", type(int.class), ImmutableList.of(argA, argB))
+                .getBody()
+                .append(binder.bindHandle(addExact).invoke(argA, argB).ret());
+
+        // the raw handle can be loaded for callers that place it on the stack themselves
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "handle", type(MethodHandle.class))
+                .getBody()
+                .append(binder.bindHandle(addExact).handle().ret());
+
+        assertThat(binder.getBindings()).containsExactly(addExact);
+
+        // invocation arguments are checked against the handle type at generation time
+        BoundMethodHandle bound = binder.bindHandle(addExact);
+        assertThat(bound.type()).isEqualTo(methodType(int.class, int.class, int.class));
+        assertThatThrownBy(() -> bound.invoke(argA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected 2 arguments");
+        assertThatThrownBy(() -> bound.invoke(argA, constantString("wrong")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected argument 1 to have type");
+
+        Class<?> clazz = hiddenClassGenerator(lookup())
+                .defineHiddenClass(classDefinition, Object.class, binder);
+
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+        assertThat(clazz.getMethod("addAgain", int.class, int.class).invoke(null, 20, 22)).isEqualTo(42);
+        assertThat(clazz.getMethod("handle").invoke(null)).isSameAs(addExact);
     }
 
     @Test

--- a/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
+++ b/src/test/java/io/airlift/bytecode/TestHiddenClassGenerator.java
@@ -82,6 +82,46 @@ class TestHiddenClassGenerator
     }
 
     @Test
+    void testClassDataBinder()
+            throws Exception
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                "io/airlift/bytecode/BinderExample",
+                type(Object.class));
+
+        ClassDataBinder binder = new ClassDataBinder();
+        String message = "hello";
+        MethodHandle addExact = lookup().findStatic(Math.class, "addExact", methodType(int.class, int.class, int.class));
+
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "message", type(String.class))
+                .getBody()
+                .append(binder.bind(message, String.class).ret());
+
+        // binding the same object again reuses its class data slot
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "sameMessage", type(String.class))
+                .getBody()
+                .append(binder.bind(message, String.class).ret());
+
+        Parameter argA = arg("a", int.class);
+        Parameter argB = arg("b", int.class);
+        classDefinition.declareMethod(a(PUBLIC, STATIC), "add", type(int.class), ImmutableList.of(argA, argB))
+                .getBody()
+                .append(binder.bind(addExact, MethodHandle.class)
+                        .invoke("invokeExact", int.class, argA, argB)
+                        .ret());
+
+        assertThat(binder.getBindings()).containsExactly(message, addExact);
+
+        Class<?> clazz = hiddenClassGenerator(lookup())
+                .defineHiddenClass(classDefinition, Object.class, Optional.of(binder.getBindings()));
+
+        assertThat(clazz.getMethod("message").invoke(null)).isSameAs(message);
+        assertThat(clazz.getMethod("sameMessage").invoke(null)).isSameAs(message);
+        assertThat(clazz.getMethod("add", int.class, int.class).invoke(null, 13, 42)).isEqualTo(55);
+    }
+
+    @Test
     void testGenerator()
             throws Exception
     {


### PR DESCRIPTION
Split out of #22.

* Add class data constant expressions (`constantClassData`/`constantClassDataAt`) loading constants via condy from a hidden class's class data
* Add ClassDataBinder for binding constants into hidden classes, deduplicating repeated bindings into stable slots
* Add `defineHiddenClass(classDefinition, superType, binder)` overload so callers don't wrap the bindings in an Optional; an empty binder defines the class without class data
* Add `ClassDataBinder.bindHandle(MethodHandle)`: generates an exact invocation with arguments checked against the handle type at generation time, or loads the raw handle for call sites that must place it on the stack below already-pushed arguments (as Trino's function invocation does)