### PR TITLE
Configure Njord release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,15 @@ jobs:
           git config user.name "Airlift Release"
           git config user.email "airlift-bot@airlift.io"
 
+      - name: Verify release configuration
+        env:
+          MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME }}
+          MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_TOKEN }}
+        run: |
+          ./mvnw -B njord:status | tee "${RUNNER_TEMP}/njord-status.log"
+          grep -F "Repository Auth: Present" "${RUNNER_TEMP}/njord-status.log"
+          grep -F "Effective URL: njord:template:release-sca" "${RUNNER_TEMP}/njord-status.log"
+
       - name: Prepare release
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-s
+${session.rootDirectory}/.mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,16 @@
+<settings>
+    <pluginGroups>
+        <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
+    </pluginGroups>
+    <servers>
+        <server>
+            <id>sonatype-central-portal</id>
+            <username>${env.MAVENCENTRAL_USERNAME}</username>
+            <password>${env.MAVENCENTRAL_PASSWORD}</password>
+            <configuration>
+                <njord.publisher>sonatype-cp</njord.publisher>
+                <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+            </configuration>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
## Why

- The release workflow follows the POM's direct Maven Central URL, which rejects uploads before Njord can validate and publish them.
- Bytecode is missing the shared Maven and Njord configuration used by successful Airlift release workflows.
- Without an early check, routing or credential problems are discovered only after release preparation has begun.

## Approach

- Load the standard Airlift Maven settings for Sonatype Central publishing through Njord.
- Verify Central authentication and the effective Njord release route before preparing a release.