### PR TITLE
Fix release publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>bytecode</artifactId>
     <version>1.7-SNAPSHOT</version>
 
+    <name>bytecode</name>
     <description>High-level library for generating JVM bytecode</description>
     <url>https://github.com/airlift/bytecode</url>
 


### PR DESCRIPTION
## Why

- Njord rejects the staged Bytecode release because the published POM lacks the required project name.
- This prevents the established release workflow from publishing the release to Maven Central.

## Approach

- Declare the Bytecode project name in the Maven metadata required by Central validation.
