### PR TITLE
Define method handle proxies as hidden classes

### DIFF
--- a/src/main/java/io/airlift/bytecode/FastMethodHandleProxies.java
+++ b/src/main/java/io/airlift/bytecode/FastMethodHandleProxies.java
@@ -14,43 +14,37 @@
 package io.airlift.bytecode;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.bytecode.control.TryCatch;
 import io.airlift.bytecode.control.TryCatch.CatchBlock;
 
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.bytecode.Access.FINAL;
 import static io.airlift.bytecode.Access.PUBLIC;
 import static io.airlift.bytecode.Access.SYNTHETIC;
 import static io.airlift.bytecode.Access.a;
-import static io.airlift.bytecode.ClassGenerator.classGenerator;
-import static io.airlift.bytecode.FastMethodHandleProxies.Bootstrap.BOOTSTRAP_METHOD;
+import static io.airlift.bytecode.HiddenClassGenerator.hiddenClassGenerator;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.ParameterizedType.typeFromJavaClassName;
-import static io.airlift.bytecode.expression.BytecodeExpressions.invokeDynamic;
+import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
 
 public final class FastMethodHandleProxies
 {
-    private static final AtomicLong CLASS_ID = new AtomicLong();
-
     private FastMethodHandleProxies() {}
 
     /**
@@ -63,8 +57,7 @@ public final class FastMethodHandleProxies
      */
     public static <T> T asInterfaceInstance(Class<T> type, MethodHandle target)
     {
-        String className = "$gen." + type.getName() + "_" + CLASS_ID.incrementAndGet();
-        return asInterfaceInstance(className, type, target);
+        return asInterfaceInstance(type.getSimpleName(), type, target);
     }
 
     /**
@@ -78,11 +71,32 @@ public final class FastMethodHandleProxies
      */
     public static <T> T asInterfaceInstance(String className, Class<T> type, MethodHandle target)
     {
+        return asInterfaceInstance(lookup(), className, type, target);
+    }
+
+    /**
+     * Faster version of {@link MethodHandleProxies#asInterfaceInstance(Class, MethodHandle)}.
+     * <p>
+     * The proxy is defined as a hidden class in the runtime package of the lookup class, so
+     * {@code type} must be visible from the lookup class rather than from this library.
+     *
+     * @param <T> the desired type of the wrapper, a single-method interface
+     * @param lookup the lookup used to define the proxy class
+     * @param className the name of the generated class
+     * @param type a class object representing {@code T}
+     * @param target the method handle to invoke from the wrapper
+     * @return a correctly-typed wrapper for the given target
+     */
+    public static <T> T asInterfaceInstance(Lookup lookup, String className, Class<T> type, MethodHandle target)
+    {
+        requireNonNull(lookup, "lookup is null");
+        requireNonNull(className, "className is null");
+        requireNonNull(target, "target is null");
         checkArgument(type.isInterface() && Modifier.isPublic(type.getModifiers()), "not a public interface: %s", type.getName());
 
         ClassDefinition classDefinition = new ClassDefinition(
                 a(PUBLIC, FINAL, SYNTHETIC),
-                typeFromJavaClassName(className),
+                typeFromJavaClassName(hiddenClassName(lookup, className)),
                 type(Object.class),
                 type(type));
 
@@ -92,10 +106,9 @@ public final class FastMethodHandleProxies
         Class<?>[] parameterTypes = method.getParameterTypes();
         MethodHandle adaptedTarget = target.asType(methodType(method.getReturnType(), parameterTypes));
 
-        List<Parameter> parameters = new ArrayList<>();
-        for (int i = 0; i < parameterTypes.length; i++) {
-            parameters.add(arg("arg" + i, parameterTypes[i]));
-        }
+        List<Parameter> parameters = IntStream.range(0, parameterTypes.length)
+                .mapToObj(i -> arg("arg" + i, parameterTypes[i]))
+                .collect(toImmutableList());
 
         MethodDefinition methodDefinition = classDefinition.declareMethod(
                 a(PUBLIC),
@@ -103,14 +116,8 @@ public final class FastMethodHandleProxies
                 type(method.getReturnType()),
                 parameters);
 
-        BytecodeNode invocation = invokeDynamic(
-                BOOTSTRAP_METHOD,
-                ImmutableList.of(),
-                method.getName(),
-                method.getReturnType(),
-                parameters)
-                .ret();
-
+        // unchecked throwables and exceptions declared by the interface method propagate
+        // as-is; anything else is wrapped, matching MethodHandleProxies
         ImmutableList.Builder<ParameterizedType> exceptionTypes = ImmutableList.builder();
         exceptionTypes.add(type(RuntimeException.class), type(Error.class));
         for (Class<?> exceptionType : method.getExceptionTypes()) {
@@ -125,23 +132,35 @@ public final class FastMethodHandleProxies
                 .invokeConstructor(UndeclaredThrowableException.class, Throwable.class)
                 .throwObject();
 
-        invocation = new TryCatch(invocation, ImmutableList.of(
+        ClassDataBinder binder = new ClassDataBinder();
+        BytecodeNode invocation = binder.bindHandle(adaptedTarget)
+                .invoke(ImmutableList.copyOf(parameters))
+                .ret();
+
+        methodDefinition.getBody().append(new TryCatch(invocation, ImmutableList.of(
                 new CatchBlock(new BytecodeBlock().throwObject(), exceptionTypes.build()),
-                new CatchBlock(throwUndeclared, ImmutableList.of())));
+                new CatchBlock(throwUndeclared, ImmutableList.of()))));
 
-        methodDefinition.getBody().append(invocation);
-
-        // note this will not work if interface class is not visible from this class loader,
-        // but we must use this class loader to ensure the bootstrap method is visible
-        ClassLoader targetClassLoader = FastMethodHandleProxies.class.getClassLoader();
-        DynamicClassLoader dynamicClassLoader = new DynamicClassLoader(targetClassLoader, ImmutableMap.of(0L, adaptedTarget));
-        Class<? extends T> newClass = classGenerator(dynamicClassLoader).defineClass(classDefinition, type);
+        Class<? extends T> newClass = hiddenClassGenerator(lookup)
+                .defineHiddenClass(classDefinition, type, binder);
         try {
             return newClass.getDeclaredConstructor().newInstance();
         }
         catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * A hidden class must be defined in the runtime package of its lookup class, so the
+     * caller's name is used only as the stem. The JVM appends a unique suffix, which makes
+     * the stem unique without a counter.
+     */
+    private static String hiddenClassName(Lookup lookup, String className)
+    {
+        String stem = className.replace('.', '$').replace('/', '$');
+        String packageName = lookup.lookupClass().getPackageName();
+        return packageName.isEmpty() ? stem : packageName + "." + stem;
     }
 
     private static <T> Method getSingleAbstractMethod(Class<T> type)
@@ -167,28 +186,5 @@ public final class FastMethodHandleProxies
                 method.getReturnType() != returnType ||
                 !name.equals(method.getName()) ||
                 !Arrays.equals(method.getParameterTypes(), parameterTypes);
-    }
-
-    public static final class Bootstrap
-    {
-        public static final Method BOOTSTRAP_METHOD;
-
-        static {
-            try {
-                BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class);
-            }
-            catch (NoSuchMethodException e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        private Bootstrap() {}
-
-        @SuppressWarnings("unused")
-        public static CallSite bootstrap(MethodHandles.Lookup callerLookup, String name, MethodType type)
-        {
-            DynamicClassLoader classLoader = (DynamicClassLoader) callerLookup.lookupClass().getClassLoader();
-            return new ConstantCallSite(classLoader.getCallSiteBindings().get(0L));
-        }
     }
 }

--- a/src/test/java/io/airlift/bytecode/TestFastMethodHandleProxies.java
+++ b/src/test/java/io/airlift/bytecode/TestFastMethodHandleProxies.java
@@ -14,11 +14,14 @@
 package io.airlift.bytecode;
 
 import com.google.common.base.VerifyException;
+import io.airlift.bytecode.fixture.IsolatedAdder;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MutableCallSite;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -248,6 +251,115 @@ class TestFastMethodHandleProxies
         int first();
 
         int second();
+    }
+
+    /**
+     * The lookup overload exists so that callers can proxy interfaces their own loader can
+     * see but this library's cannot. The fixture package is reloaded in an isolated loader,
+     * which yields an interface distinct from the one on the test classpath and unreachable
+     * from the loader that defined {@link FastMethodHandleProxies}.
+     */
+    @Test
+    void testInterfaceInvisibleToLibraryLoader()
+            throws ReflectiveOperationException
+    {
+        IsolatedClassLoader isolated = new IsolatedClassLoader(getClass().getClassLoader(), "io.airlift.bytecode.fixture.");
+        Class<?> isolatedAdder = isolated.loadClass("io.airlift.bytecode.fixture.IsolatedAdder");
+        Lookup isolatedLookup = (Lookup) isolated.loadClass("io.airlift.bytecode.fixture.IsolatedLookup")
+                .getMethod("lookup").invoke(null);
+
+        // the isolated interface really is a different class than the one this test compiled against
+        assertThat(isolatedAdder).isNotSameAs(IsolatedAdder.class);
+        assertThat(isolatedAdder.getClassLoader()).isSameAs(isolated);
+        // and the library's own loader resolves that name to a different class
+        assertThat(FastMethodHandleProxies.class.getClassLoader().loadClass(isolatedAdder.getName()))
+                .isNotSameAs(isolatedAdder);
+
+        MethodHandle target = lookup().findStatic(getClass(), "add", methodType(int.class, int.class, int.class));
+        Object proxy = FastMethodHandleProxies.asInterfaceInstance(isolatedLookup, "Adder", isolatedAdder, target);
+
+        assertThat(isolatedAdder.isInstance(proxy)).isTrue();
+        assertThat(proxy.getClass().isHidden()).isTrue();
+        // the proxy is defined in the lookup's loader and package, which is how it sees the interface
+        assertThat(proxy.getClass().getClassLoader()).isSameAs(isolated);
+        assertThat(proxy.getClass().getPackageName()).isEqualTo("io.airlift.bytecode.fixture");
+        assertThat(isolatedAdder.getMethod("add", int.class, int.class).invoke(proxy, 13, 42)).isEqualTo(55);
+    }
+
+    /**
+     * The counterpart to {@link #testInterfaceInvisibleToLibraryLoader()}: without a caller
+     * lookup the proxy lands in this library's loader, which cannot see the isolated interface.
+     */
+    @Test
+    void testInterfaceInvisibleToLibraryLoaderIsRejected()
+            throws ReflectiveOperationException
+    {
+        IsolatedClassLoader isolated = new IsolatedClassLoader(getClass().getClassLoader(), "io.airlift.bytecode.fixture.");
+        Class<?> isolatedAdder = isolated.loadClass("io.airlift.bytecode.fixture.IsolatedAdder");
+
+        MethodHandle target = lookup().findStatic(getClass(), "add", methodType(int.class, int.class, int.class));
+        assertThatThrownBy(() -> FastMethodHandleProxies.asInterfaceInstance(isolatedAdder, target))
+                .isInstanceOf(ClassCastException.class);
+    }
+
+    private static int add(int a, int b)
+    {
+        return a + b;
+    }
+
+    /**
+     * Loads classes under a package prefix itself rather than delegating, so they are
+     * distinct from, and invisible to, the classes the parent loader defines.
+     */
+    private static final class IsolatedClassLoader
+            extends ClassLoader
+    {
+        private final String packagePrefix;
+
+        private IsolatedClassLoader(ClassLoader parent, String packagePrefix)
+        {
+            super(parent);
+            this.packagePrefix = packagePrefix;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException
+        {
+            if (!name.startsWith(packagePrefix)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    loaded = defineClass(name, readClassBytes(name));
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+
+        private Class<?> defineClass(String name, byte[] bytes)
+        {
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+
+        private byte[] readClassBytes(String name)
+                throws ClassNotFoundException
+        {
+            String resource = name.replace('.', '/') + ".class";
+            try (InputStream input = getParent().getResourceAsStream(resource)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                return input.readAllBytes();
+            }
+            catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
     }
 
     private static <T> void assertInterface(Class<T> interfaceType, MethodHandle target, Consumer<T> consumer)

--- a/src/test/java/io/airlift/bytecode/TestFastMethodHandleProxies.java
+++ b/src/test/java/io/airlift/bytecode/TestFastMethodHandleProxies.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MutableCallSite;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.Consumer;
 import java.util.function.IntSupplier;
@@ -155,6 +156,98 @@ class TestFastMethodHandleProxies
     private static int two()
     {
         return 2;
+    }
+
+    @Test
+    void testHiddenClass()
+            throws ReflectiveOperationException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+        IntSupplier supplier = FastMethodHandleProxies.asInterfaceInstance(IntSupplier.class, target);
+
+        Class<?> proxyClass = supplier.getClass();
+        assertThat(proxyClass.isHidden()).isTrue();
+        // a hidden class lives in the runtime package of its lookup class
+        assertThat(proxyClass.getPackageName()).isEqualTo(FastMethodHandleProxies.class.getPackageName());
+        // and is not discoverable by name
+        assertThatThrownBy(() -> Class.forName(proxyClass.getName()))
+                .isInstanceOf(ClassNotFoundException.class);
+    }
+
+    @Test
+    void testClassNameIsUsedAsStem()
+            throws ReflectiveOperationException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+        IntSupplier supplier = FastMethodHandleProxies.asInterfaceInstance("MyProxy", IntSupplier.class, target);
+
+        // the JVM appends "/0x..." to make the name unique, so the requested name is only a stem
+        assertThat(supplier.getClass().getName())
+                .startsWith(FastMethodHandleProxies.class.getPackageName() + ".MyProxy/");
+    }
+
+    @Test
+    void testProxyClassIsUnloaded()
+            throws ReflectiveOperationException, InterruptedException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+
+        WeakReference<Class<?>> proxyClass = createProxyClassReference(target);
+
+        // the proxy is unreachable, so its hidden class must become collectable
+        for (int i = 0; i < 100 && proxyClass.get() != null; i++) {
+            System.gc();
+            Thread.sleep(10);
+        }
+        assertThat(proxyClass.get()).isNull();
+    }
+
+    private static WeakReference<Class<?>> createProxyClassReference(MethodHandle target)
+    {
+        IntSupplier supplier = FastMethodHandleProxies.asInterfaceInstance(IntSupplier.class, target);
+        assertThat(supplier.getAsInt()).isEqualTo(1);
+        return new WeakReference<>(supplier.getClass());
+    }
+
+    @Test
+    void testNonPublicInterface()
+            throws ReflectiveOperationException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+        assertThatThrownBy(() -> FastMethodHandleProxies.asInterfaceInstance(PackagePrivate.class, target))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a public interface");
+    }
+
+    interface PackagePrivate
+    {
+        int value();
+    }
+
+    @Test
+    void testNotAnInterface()
+            throws ReflectiveOperationException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+        assertThatThrownBy(() -> FastMethodHandleProxies.asInterfaceInstance(String.class, target))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a public interface");
+    }
+
+    @Test
+    void testMultipleAbstractMethods()
+            throws ReflectiveOperationException
+    {
+        MethodHandle target = lookup().findStatic(getClass(), "one", methodType(int.class));
+        assertThatThrownBy(() -> FastMethodHandleProxies.asInterfaceInstance(TwoMethods.class, target))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    public interface TwoMethods
+    {
+        int first();
+
+        int second();
     }
 
     private static <T> void assertInterface(Class<T> interfaceType, MethodHandle target, Consumer<T> consumer)

--- a/src/test/java/io/airlift/bytecode/fixture/IsolatedAdder.java
+++ b/src/test/java/io/airlift/bytecode/fixture/IsolatedAdder.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode.fixture;
+
+/**
+ * A public single-method interface used to test proxying an interface that the
+ * bytecode library's own class loader cannot reach. Loaded into an isolated class
+ * loader by the test, which produces a class distinct from the one on the test
+ * classpath.
+ */
+public interface IsolatedAdder
+{
+    int add(int a, int b);
+}

--- a/src/test/java/io/airlift/bytecode/fixture/IsolatedLookup.java
+++ b/src/test/java/io/airlift/bytecode/fixture/IsolatedLookup.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bytecode.fixture;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+/**
+ * Yields a lookup for whichever class loader defined this class, so a test can obtain
+ * a lookup in an isolated loader without reflecting over private state.
+ */
+public final class IsolatedLookup
+{
+    private IsolatedLookup() {}
+
+    public static Lookup lookup()
+    {
+        return MethodHandles.lookup();
+    }
+}


### PR DESCRIPTION
Replace the DynamicClassLoader-per-proxy and invokedynamic linkage in FastMethodHandleProxies with a hidden class carrying the adapted target as class data, invoked exactly.

Each proxy previously pinned a class loader that could not be unloaded until the proxy died, and linked through a nested Bootstrap method that read the handle back out of the loader's callsite bindings. A hidden class is collectable once the proxy is unreachable, and the handle is loaded as a dynamic constant that the JIT folds.

SAM detection, asType adaptation, checked exception declaration, and the UndeclaredThrowableException wrapping are unchanged, so behavior still matches MethodHandleProxies.asInterfaceInstance.

A hidden class must live in the runtime package of its lookup class, so the requested class name is now only a stem: it is flattened into that package, and the JVM appends a unique suffix. Add an overload taking a Lookup, which lets callers proxy interfaces that are not visible from this library. Remove the now-unused Bootstrap class.